### PR TITLE
fix: OIDC subject を environment:production に修正

### DIFF
--- a/cdk/lib/github-oidc-stack.ts
+++ b/cdk/lib/github-oidc-stack.ts
@@ -26,7 +26,7 @@ export class GithubOidcStack extends cdk.Stack {
           },
           StringLike: {
             'token.actions.githubusercontent.com:sub':
-              'repo:kyiku/hackz-megalo-back:ref:refs/heads/main',
+              'repo:kyiku/hackz-megalo-back:environment:production',
           },
         },
       ),


### PR DESCRIPTION
## Summary
- GitHub Actions の `environment: production` 使用時、OIDC token の subject が `environment:production` になるため trust policy を修正

## Test plan
- [x] OIDC スタックをローカルから再デプロイ済み
- [ ] main マージ後に deploy ジョブが成功すること