### PR TITLE
feat: session-create Lambda 実装

### DIFF
--- a/src/functions/session-create/handler.test.ts
+++ b/src/functions/session-create/handler.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockPutSession, mockGeneratePresignedUploadUrl } = vi.hoisted(() => ({
+  mockPutSession: vi.fn(),
+  mockGeneratePresignedUploadUrl: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  putSession: (...args: unknown[]) => mockPutSession(...args) as unknown,
+}))
+
+vi.mock('../../lib/s3', () => ({
+  generatePresignedUploadUrl: (...args: unknown[]) =>
+    mockGeneratePresignedUploadUrl(...args) as unknown,
+}))
+
+vi.mock('node:crypto', () => ({
+  randomUUID: () => 'test-uuid-1234',
+}))
+
+import { handler } from './handler'
+
+const createEvent = (body: unknown): APIGatewayProxyEvent =>
+  ({
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'POST',
+    isBase64Encoded: false,
+    path: '/api/session',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
+    resource: '',
+  }) as APIGatewayProxyEvent
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const invoke = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const result = await handler(event, mockContext, noop)
+  return result as APIGatewayProxyResult
+}
+
+describe('session-create handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.WEBSOCKET_URL = 'wss://test.execute-api.ap-northeast-1.amazonaws.com/dev'
+  })
+
+  it('should create a session and return upload URLs', async () => {
+    mockPutSession.mockResolvedValueOnce(undefined)
+    mockGeneratePresignedUploadUrl.mockImplementation(
+      (key: string) => Promise.resolve(`https://presigned/${key}`),
+    )
+
+    const event = createEvent({
+      filterType: 'simple',
+      filter: 'beauty',
+      photoCount: 4,
+    })
+
+    const response = await invoke(event)
+    expect(response.statusCode).toBe(201)
+
+    const body = JSON.parse(response.body) as {
+      sessionId: string
+      uploadUrls: { index: number; url: string }[]
+      websocketUrl: string
+    }
+    expect(body.sessionId).toBe('test-uuid-1234')
+    expect(body.uploadUrls).toHaveLength(4)
+    expect(body.uploadUrls[0]).toEqual({
+      index: 1,
+      url: 'https://presigned/originals/test-uuid-1234/1.jpg',
+    })
+    expect(body.websocketUrl).toBe(
+      'wss://test.execute-api.ap-northeast-1.amazonaws.com/dev',
+    )
+  })
+
+  it('should use default photoCount of 4', async () => {
+    mockPutSession.mockResolvedValueOnce(undefined)
+    mockGeneratePresignedUploadUrl.mockResolvedValue('https://presigned/url')
+
+    const event = createEvent({
+      filterType: 'simple',
+      filter: 'natural',
+    })
+
+    const response = await invoke(event)
+    const body = JSON.parse(response.body) as {
+      uploadUrls: { index: number; url: string }[]
+    }
+    expect(body.uploadUrls).toHaveLength(4)
+  })
+
+  it('should save session to DynamoDB with correct attributes', async () => {
+    mockPutSession.mockResolvedValueOnce(undefined)
+    mockGeneratePresignedUploadUrl.mockResolvedValue('https://presigned/url')
+
+    const event = createEvent({
+      filterType: 'ai',
+      filter: 'anime',
+      photoCount: 2,
+    })
+
+    await invoke(event)
+
+    expect(mockPutSession).toHaveBeenCalledOnce()
+    expect(mockPutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'test-uuid-1234',
+        filterType: 'ai',
+        filter: 'anime',
+        status: 'uploading',
+        photoCount: 2,
+      }),
+    )
+  })
+
+  it('should return 400 for invalid body', async () => {
+    const event = createEvent({
+      filterType: 'invalid',
+      filter: 'beauty',
+    })
+
+    const response = await invoke(event)
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('should return 400 for missing body', async () => {
+    const event = { ...createEvent({}), body: null } as APIGatewayProxyEvent
+
+    const response = await invoke(event)
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('should return 500 when DynamoDB fails', async () => {
+    mockPutSession.mockRejectedValueOnce(new Error('DynamoDB error'))
+    mockGeneratePresignedUploadUrl.mockResolvedValue('https://presigned/url')
+
+    const event = createEvent({
+      filterType: 'simple',
+      filter: 'mono',
+      photoCount: 1,
+    })
+
+    const response = await invoke(event)
+    expect(response.statusCode).toBe(500)
+    expect(JSON.parse(response.body)).toHaveProperty('error')
+  })
+
+  it('should return 500 when WEBSOCKET_URL is not set', async () => {
+    delete process.env.WEBSOCKET_URL
+    mockPutSession.mockResolvedValueOnce(undefined)
+    mockGeneratePresignedUploadUrl.mockResolvedValue('https://presigned/url')
+
+    const event = createEvent({
+      filterType: 'simple',
+      filter: 'beauty',
+    })
+
+    const response = await invoke(event)
+    expect(response.statusCode).toBe(500)
+  })
+})

--- a/src/functions/session-create/handler.ts
+++ b/src/functions/session-create/handler.ts
@@ -1,10 +1,55 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { randomUUID } from 'node:crypto'
+import { CreateSessionSchema } from '../../utils/validation'
+import { putSession } from '../../lib/dynamodb'
+import { generatePresignedUploadUrl } from '../../lib/s3'
+import { success, error } from '../../utils/response'
+import type { Session } from '../../lib/types'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return {
-    statusCode: 200,
-    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-    body: JSON.stringify({ message: 'TODO: implement' }),
+const TTL_DAYS = 30
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const websocketUrl = process.env.WEBSOCKET_URL
+    if (!websocketUrl) {
+      return error('WEBSOCKET_URL is not set', 500)
+    }
+
+    const parsed = CreateSessionSchema.safeParse(
+      JSON.parse(event.body ?? '{}'),
+    )
+    if (!parsed.success) {
+      return error(parsed.error.message, 400)
+    }
+
+    const { filterType, filter, photoCount } = parsed.data
+    const sessionId = randomUUID()
+    const now = new Date()
+
+    const session: Session = {
+      sessionId,
+      createdAt: now.toISOString(),
+      filterType,
+      filter,
+      status: 'uploading',
+      photoCount,
+      ttl: Math.floor(now.getTime() / 1000) + TTL_DAYS * 86400,
+    }
+
+    const uploadUrls = await Promise.all(
+      Array.from({ length: photoCount }, async (_, i) => ({
+        index: i + 1,
+        url: await generatePresignedUploadUrl(
+          `originals/${sessionId}/${String(i + 1)}.jpg`,
+        ),
+      })),
+    )
+
+    await putSession(session)
+
+    return success({ sessionId, uploadUrls, websocketUrl }, 201)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Internal server error'
+    return error(message, 500)
   }
 }


### PR DESCRIPTION
## Summary
- `POST /api/session` の Lambda ハンドラ実装
- Zod バリデーション、UUID セッション ID 生成、DynamoDB 保存、S3 Presigned Upload URL 生成
- 7テスト追加（正常系、バリデーションエラー、DynamoDB エラー、環境変数未設定）

## Test plan
- [x] 7 テスト全パス (`npm run test`)
- [x] ESLint パス (`npm run lint`)
- [x] 型チェックパス (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)