### PR TITLE
feat: session-get Lambda 実装

### DIFF
--- a/src/functions/session-get/handler.test.ts
+++ b/src/functions/session-get/handler.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockGetSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const createEvent = (sessionId: string): APIGatewayProxyEvent =>
+  ({
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: `/api/session/${sessionId}`,
+    pathParameters: { sessionId },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
+    resource: '',
+  }) as APIGatewayProxyEvent
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const invoke = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const result = await handler(event, mockContext, noop)
+  return result as APIGatewayProxyResult
+}
+
+describe('session-get handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return a session when found', async () => {
+    const session = {
+      sessionId: 'test-uuid',
+      createdAt: '2026-03-16T14:30:00Z',
+      filterType: 'simple',
+      filter: 'beauty',
+      status: 'uploading',
+      photoCount: 4,
+      ttl: 0,
+    }
+    mockGetSession.mockResolvedValueOnce(session)
+
+    const response = await invoke(createEvent('test-uuid'))
+    expect(response.statusCode).toBe(200)
+
+    const body = JSON.parse(response.body) as Record<string, unknown>
+    expect(body.sessionId).toBe('test-uuid')
+    expect(body.status).toBe('uploading')
+    expect(body.filterType).toBe('simple')
+  })
+
+  it('should return 404 when session not found', async () => {
+    mockGetSession.mockResolvedValueOnce(undefined)
+
+    const response = await invoke(createEvent('nonexistent'))
+    expect(response.statusCode).toBe(404)
+
+    const body = JSON.parse(response.body) as { error: string }
+    expect(body.error).toBe('Session not found')
+  })
+
+  it('should return 400 when sessionId is missing', async () => {
+    const event = {
+      ...createEvent(''),
+      pathParameters: null,
+    } as unknown as APIGatewayProxyEvent
+
+    const response = await invoke(event)
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('should return 500 when DynamoDB fails', async () => {
+    mockGetSession.mockRejectedValueOnce(new Error('DynamoDB error'))
+
+    const response = await invoke(createEvent('test-uuid'))
+    expect(response.statusCode).toBe(500)
+    expect(JSON.parse(response.body)).toHaveProperty('error')
+  })
+})

--- a/src/functions/session-get/handler.ts
+++ b/src/functions/session-get/handler.ts
@@ -1,10 +1,22 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { getSession } from '../../lib/dynamodb'
+import { success, error } from '../../utils/response'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return {
-    statusCode: 200,
-    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-    body: JSON.stringify({ message: 'TODO: implement' }),
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const sessionId = event.pathParameters?.sessionId
+    if (!sessionId) {
+      return error('sessionId is required', 400)
+    }
+
+    const session = await getSession(sessionId)
+    if (!session) {
+      return error('Session not found', 404)
+    }
+
+    return success(session)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Internal server error'
+    return error(message, 500)
   }
 }


### PR DESCRIPTION
## Summary
- `GET /api/session/:sessionId` の Lambda ハンドラ実装
- DynamoDB からセッション取得、見つからない場合は 404 レスポンス
- 4テスト追加（正常系、404、400、500）

## Test plan
- [x] 69 テスト全パス (`npm run test`)
- [x] ESLint パス (`npm run lint`)
- [x] 型チェックパス (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)