### PR TITLE
feat: WebSocket接続系Lambda実装

### DIFF
--- a/src/functions/ws-connect/handler.test.ts
+++ b/src/functions/ws-connect/handler.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockPutConnection } = vi.hoisted(() => ({
+  mockPutConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  putConnection: (...args: unknown[]) => mockPutConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createConnectEvent = (connectionId: string) =>
+  ({
+    requestContext: {
+      connectionId,
+      eventType: 'CONNECT',
+    },
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-connect handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should save connection and return 200', async () => {
+    mockPutConnection.mockResolvedValueOnce(undefined)
+
+    const result = (await handler(
+      createConnectEvent('conn-123'),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockPutConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'conn-123',
+      }),
+    )
+  })
+
+  it('should return 500 when DynamoDB fails', async () => {
+    mockPutConnection.mockRejectedValueOnce(new Error('DynamoDB error'))
+
+    const result = (await handler(
+      createConnectEvent('conn-123'),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(500)
+  })
+})

--- a/src/functions/ws-connect/handler.ts
+++ b/src/functions/ws-connect/handler.ts
@@ -1,6 +1,25 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { putConnection } from '../../lib/dynamodb'
+import type { Connection } from '../../lib/types'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    const now = Date.now()
+    const connection: Connection = {
+      connectionId,
+      connectedAt: now,
+      ttl: Math.floor(now / 1000) + 86400,
+    }
+
+    await putConnection(connection)
+
+    return { statusCode: 200, body: 'Connected' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }

--- a/src/functions/ws-disconnect/handler.test.ts
+++ b/src/functions/ws-disconnect/handler.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockDeleteConnection } = vi.hoisted(() => ({
+  mockDeleteConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  deleteConnection: (...args: unknown[]) => mockDeleteConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createDisconnectEvent = (connectionId: string) =>
+  ({
+    requestContext: {
+      connectionId,
+      eventType: 'DISCONNECT',
+    },
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-disconnect handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should delete connection and return 200', async () => {
+    mockDeleteConnection.mockResolvedValueOnce(undefined)
+
+    const result = (await handler(
+      createDisconnectEvent('conn-123'),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockDeleteConnection).toHaveBeenCalledWith('conn-123')
+  })
+
+  it('should return 500 when DynamoDB fails', async () => {
+    mockDeleteConnection.mockRejectedValueOnce(new Error('DynamoDB error'))
+
+    const result = (await handler(
+      createDisconnectEvent('conn-123'),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(500)
+  })
+})

--- a/src/functions/ws-disconnect/handler.ts
+++ b/src/functions/ws-disconnect/handler.ts
@@ -1,6 +1,16 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { deleteConnection } from '../../lib/dynamodb'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    await deleteConnection(connectionId)
+    return { statusCode: 200, body: 'Disconnected' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }

--- a/src/functions/ws-subscribe/handler.test.ts
+++ b/src/functions/ws-subscribe/handler.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockUpdateConnection } = vi.hoisted(() => ({
+  mockUpdateConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  updateConnection: (...args: unknown[]) => mockUpdateConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createSubscribeEvent = (connectionId: string, body: unknown) =>
+  ({
+    requestContext: {
+      connectionId,
+      eventType: 'MESSAGE',
+      routeKey: 'subscribe',
+    },
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-subscribe handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should subscribe connection to session and return 200', async () => {
+    mockUpdateConnection.mockResolvedValueOnce(undefined)
+
+    const result = (await handler(
+      createSubscribeEvent('conn-123', { action: 'subscribe', data: { sessionId: '550e8400-e29b-41d4-a716-446655440000' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockUpdateConnection).toHaveBeenCalledWith('conn-123', {
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+    })
+  })
+
+  it('should return 400 for invalid body', async () => {
+    const result = (await handler(
+      createSubscribeEvent('conn-123', { action: 'subscribe', data: {} }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('should return 400 for missing body', async () => {
+    const event = {
+      ...createSubscribeEvent('conn-123', {}),
+      body: null,
+    } as Parameters<typeof handler>[0]
+
+    const result = (await handler(event, mockContext, noop)) as APIGatewayProxyResult
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('should return 500 when DynamoDB fails', async () => {
+    mockUpdateConnection.mockRejectedValueOnce(new Error('DynamoDB error'))
+
+    const result = (await handler(
+      createSubscribeEvent('conn-123', { action: 'subscribe', data: { sessionId: '550e8400-e29b-41d4-a716-446655440000' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(500)
+  })
+})

--- a/src/functions/ws-subscribe/handler.ts
+++ b/src/functions/ws-subscribe/handler.ts
@@ -1,6 +1,24 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { updateConnection } from '../../lib/dynamodb'
+import { SubscribeSchema } from '../../utils/validation'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    const body = JSON.parse(event.body ?? '{}') as Record<string, unknown>
+    const parsed = SubscribeSchema.safeParse(body.data)
+    if (!parsed.success) {
+      return { statusCode: 400, body: parsed.error.message }
+    }
+
+    await updateConnection(connectionId, { sessionId: parsed.data.sessionId })
+
+    return { statusCode: 200, body: 'Subscribed' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }


### PR DESCRIPTION
## Summary
- `ws-connect`: $connect ルート → connections テーブルに接続情報保存 (2テスト)
- `ws-disconnect`: $disconnect ルート → connections テーブルから削除 (2テスト)
- `ws-subscribe`: subscribe アクション → connectionId に sessionId を紐付け (4テスト)

## Test plan
- [x] 85 テスト全パス (`npm run test`)
- [x] ESLint パス (`npm run lint`)
- [x] 型チェックパス (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)