### PR TITLE
feat: WebSocketシグナリング系Lambda実装

### DIFF
--- a/src/functions/ws-join-room/handler.test.ts
+++ b/src/functions/ws-join-room/handler.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockUpdateConnection } = vi.hoisted(() => ({
+  mockUpdateConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  updateConnection: (...args: unknown[]) => mockUpdateConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createEvent = (connectionId: string, body: unknown) =>
+  ({
+    requestContext: { connectionId, eventType: 'MESSAGE', routeKey: 'join_room' },
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-join-room handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should join room and return 200', async () => {
+    mockUpdateConnection.mockResolvedValueOnce(undefined)
+
+    const result = (await handler(
+      createEvent('conn-1', { action: 'join_room', data: { roomId: 'room-1', role: 'phone' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockUpdateConnection).toHaveBeenCalledWith('conn-1', {
+      roomId: 'room-1',
+      role: 'phone',
+    })
+  })
+
+  it('should return 400 for invalid role', async () => {
+    const result = (await handler(
+      createEvent('conn-1', { action: 'join_room', data: { roomId: 'room-1', role: 'invalid' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('should return 400 for missing body', async () => {
+    const event = { ...createEvent('conn-1', {}), body: null } as Parameters<typeof handler>[0]
+
+    const result = (await handler(event, mockContext, noop)) as APIGatewayProxyResult
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('should return 500 when DynamoDB fails', async () => {
+    mockUpdateConnection.mockRejectedValueOnce(new Error('fail'))
+
+    const result = (await handler(
+      createEvent('conn-1', { action: 'join_room', data: { roomId: 'room-1', role: 'pc' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(500)
+  })
+})

--- a/src/functions/ws-join-room/handler.ts
+++ b/src/functions/ws-join-room/handler.ts
@@ -1,6 +1,27 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { updateConnection } from '../../lib/dynamodb'
+import { JoinRoomSchema } from '../../utils/validation'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    const body = JSON.parse(event.body ?? '{}') as Record<string, unknown>
+    const parsed = JoinRoomSchema.safeParse(body.data)
+    if (!parsed.success) {
+      return { statusCode: 400, body: parsed.error.message }
+    }
+
+    await updateConnection(connectionId, {
+      roomId: parsed.data.roomId,
+      role: parsed.data.role,
+    })
+
+    return { statusCode: 200, body: 'Joined' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }

--- a/src/functions/ws-shooting-sync/handler.test.ts
+++ b/src/functions/ws-shooting-sync/handler.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockQueryConnectionsByRoomId, mockSendToConnection } = vi.hoisted(() => ({
+  mockQueryConnectionsByRoomId: vi.fn(),
+  mockSendToConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  queryConnectionsByRoomId: (...args: unknown[]) =>
+    mockQueryConnectionsByRoomId(...args) as unknown,
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToConnection: (...args: unknown[]) => mockSendToConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createEvent = (connectionId: string, body: unknown) =>
+  ({
+    requestContext: { connectionId, eventType: 'MESSAGE', routeKey: 'shooting_sync' },
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-shooting-sync handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should relay shooting_start event to other connections', async () => {
+    mockQueryConnectionsByRoomId.mockResolvedValueOnce([
+      { connectionId: 'phone-1', connectedAt: 0, ttl: 0 },
+      { connectionId: 'pc-1', connectedAt: 0, ttl: 0 },
+    ])
+    mockSendToConnection.mockResolvedValue(undefined)
+
+    const data = {
+      roomId: 'room-1',
+      event: 'shooting_start',
+      sessionId: 'session-1',
+      totalPhotos: 4,
+    }
+
+    const result = (await handler(
+      createEvent('phone-1', { action: 'shooting_sync', data }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockSendToConnection).toHaveBeenCalledOnce()
+    expect(mockSendToConnection).toHaveBeenCalledWith('pc-1', {
+      type: 'shooting_sync',
+      data: {
+        event: 'shooting_start',
+        sessionId: 'session-1',
+        totalPhotos: 4,
+      },
+    })
+  })
+
+  it('should relay countdown event', async () => {
+    mockQueryConnectionsByRoomId.mockResolvedValueOnce([
+      { connectionId: 'phone-1', connectedAt: 0, ttl: 0 },
+      { connectionId: 'pc-1', connectedAt: 0, ttl: 0 },
+    ])
+    mockSendToConnection.mockResolvedValue(undefined)
+
+    const data = {
+      roomId: 'room-1',
+      event: 'countdown',
+      photoIndex: 1,
+      count: 3,
+    }
+
+    const result = (await handler(
+      createEvent('phone-1', { action: 'shooting_sync', data }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+  })
+
+  it('should return 400 for invalid event type', async () => {
+    const result = (await handler(
+      createEvent('conn-1', { action: 'shooting_sync', data: { roomId: 'room-1', event: 'invalid' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('should return 500 on error', async () => {
+    mockQueryConnectionsByRoomId.mockRejectedValueOnce(new Error('fail'))
+
+    const result = (await handler(
+      createEvent('conn-1', { action: 'shooting_sync', data: { roomId: 'room-1', event: 'shutter', photoIndex: 1 } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(500)
+  })
+})

--- a/src/functions/ws-shooting-sync/handler.ts
+++ b/src/functions/ws-shooting-sync/handler.ts
@@ -1,6 +1,37 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { queryConnectionsByRoomId } from '../../lib/dynamodb'
+import { sendToConnection } from '../../lib/websocket'
+import { ShootingSyncSchema } from '../../utils/validation'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    const body = JSON.parse(event.body ?? '{}') as Record<string, unknown>
+    const parsed = ShootingSyncSchema.safeParse(body.data)
+    if (!parsed.success) {
+      return { statusCode: 400, body: parsed.error.message }
+    }
+
+    const { roomId, ...eventData } = parsed.data
+
+    const connections = await queryConnectionsByRoomId(roomId)
+    const others = connections.filter((c) => c.connectionId !== connectionId)
+
+    await Promise.all(
+      others.map((c) =>
+        sendToConnection(c.connectionId, {
+          type: 'shooting_sync',
+          data: eventData,
+        }),
+      ),
+    )
+
+    return { statusCode: 200, body: 'OK' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }

--- a/src/functions/ws-webrtc-answer/handler.test.ts
+++ b/src/functions/ws-webrtc-answer/handler.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockQueryConnectionsByRoomId, mockSendToConnection } = vi.hoisted(() => ({
+  mockQueryConnectionsByRoomId: vi.fn(),
+  mockSendToConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  queryConnectionsByRoomId: (...args: unknown[]) =>
+    mockQueryConnectionsByRoomId(...args) as unknown,
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToConnection: (...args: unknown[]) => mockSendToConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createEvent = (connectionId: string, body: unknown) =>
+  ({
+    requestContext: { connectionId, eventType: 'MESSAGE', routeKey: 'webrtc_answer' },
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-webrtc-answer handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should relay answer to other connections in room', async () => {
+    mockQueryConnectionsByRoomId.mockResolvedValueOnce([
+      { connectionId: 'conn-1', connectedAt: 0, ttl: 0 },
+      { connectionId: 'conn-2', connectedAt: 0, ttl: 0 },
+    ])
+    mockSendToConnection.mockResolvedValue(undefined)
+
+    const result = (await handler(
+      createEvent('conn-2', { action: 'webrtc_answer', data: { roomId: 'room-1', sdp: 'v=0...' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockSendToConnection).toHaveBeenCalledOnce()
+    expect(mockSendToConnection).toHaveBeenCalledWith('conn-1', {
+      type: 'webrtc_answer',
+      data: { sdp: 'v=0...' },
+    })
+  })
+
+  it('should return 400 for invalid body', async () => {
+    const result = (await handler(
+      createEvent('conn-1', { action: 'webrtc_answer', data: { roomId: 'room-1' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(400)
+  })
+})

--- a/src/functions/ws-webrtc-answer/handler.ts
+++ b/src/functions/ws-webrtc-answer/handler.ts
@@ -1,6 +1,35 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { queryConnectionsByRoomId } from '../../lib/dynamodb'
+import { sendToConnection } from '../../lib/websocket'
+import { WebrtcSdpSchema } from '../../utils/validation'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    const body = JSON.parse(event.body ?? '{}') as Record<string, unknown>
+    const parsed = WebrtcSdpSchema.safeParse(body.data)
+    if (!parsed.success) {
+      return { statusCode: 400, body: parsed.error.message }
+    }
+
+    const connections = await queryConnectionsByRoomId(parsed.data.roomId)
+    const others = connections.filter((c) => c.connectionId !== connectionId)
+
+    await Promise.all(
+      others.map((c) =>
+        sendToConnection(c.connectionId, {
+          type: 'webrtc_answer',
+          data: { sdp: parsed.data.sdp },
+        }),
+      ),
+    )
+
+    return { statusCode: 200, body: 'OK' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }

--- a/src/functions/ws-webrtc-ice/handler.test.ts
+++ b/src/functions/ws-webrtc-ice/handler.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockQueryConnectionsByRoomId, mockSendToConnection } = vi.hoisted(() => ({
+  mockQueryConnectionsByRoomId: vi.fn(),
+  mockSendToConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  queryConnectionsByRoomId: (...args: unknown[]) =>
+    mockQueryConnectionsByRoomId(...args) as unknown,
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToConnection: (...args: unknown[]) => mockSendToConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createEvent = (connectionId: string, body: unknown) =>
+  ({
+    requestContext: { connectionId, eventType: 'MESSAGE', routeKey: 'webrtc_ice' },
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-webrtc-ice handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should relay ICE candidate to other connections in room', async () => {
+    mockQueryConnectionsByRoomId.mockResolvedValueOnce([
+      { connectionId: 'conn-1', connectedAt: 0, ttl: 0 },
+      { connectionId: 'conn-2', connectedAt: 0, ttl: 0 },
+    ])
+    mockSendToConnection.mockResolvedValue(undefined)
+
+    const result = (await handler(
+      createEvent('conn-1', { action: 'webrtc_ice', data: { roomId: 'room-1', candidate: 'candidate:...' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockSendToConnection).toHaveBeenCalledOnce()
+    expect(mockSendToConnection).toHaveBeenCalledWith('conn-2', {
+      type: 'webrtc_ice',
+      data: { candidate: 'candidate:...' },
+    })
+  })
+
+  it('should return 400 for invalid body', async () => {
+    const result = (await handler(
+      createEvent('conn-1', { action: 'webrtc_ice', data: { roomId: 'room-1' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(400)
+  })
+})

--- a/src/functions/ws-webrtc-ice/handler.ts
+++ b/src/functions/ws-webrtc-ice/handler.ts
@@ -1,6 +1,35 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { queryConnectionsByRoomId } from '../../lib/dynamodb'
+import { sendToConnection } from '../../lib/websocket'
+import { WebrtcIceSchema } from '../../utils/validation'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    const body = JSON.parse(event.body ?? '{}') as Record<string, unknown>
+    const parsed = WebrtcIceSchema.safeParse(body.data)
+    if (!parsed.success) {
+      return { statusCode: 400, body: parsed.error.message }
+    }
+
+    const connections = await queryConnectionsByRoomId(parsed.data.roomId)
+    const others = connections.filter((c) => c.connectionId !== connectionId)
+
+    await Promise.all(
+      others.map((c) =>
+        sendToConnection(c.connectionId, {
+          type: 'webrtc_ice',
+          data: { candidate: parsed.data.candidate },
+        }),
+      ),
+    )
+
+    return { statusCode: 200, body: 'OK' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }

--- a/src/functions/ws-webrtc-offer/handler.test.ts
+++ b/src/functions/ws-webrtc-offer/handler.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyResult, Context } from 'aws-lambda'
+
+const { mockQueryConnectionsByRoomId, mockSendToConnection } = vi.hoisted(() => ({
+  mockQueryConnectionsByRoomId: vi.fn(),
+  mockSendToConnection: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  queryConnectionsByRoomId: (...args: unknown[]) =>
+    mockQueryConnectionsByRoomId(...args) as unknown,
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToConnection: (...args: unknown[]) => mockSendToConnection(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createEvent = (connectionId: string, body: unknown) =>
+  ({
+    requestContext: { connectionId, eventType: 'MESSAGE', routeKey: 'webrtc_offer' },
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  }) as Parameters<typeof handler>[0]
+
+describe('ws-webrtc-offer handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should relay offer to other connections in room', async () => {
+    mockQueryConnectionsByRoomId.mockResolvedValueOnce([
+      { connectionId: 'conn-1', connectedAt: 0, ttl: 0 },
+      { connectionId: 'conn-2', connectedAt: 0, ttl: 0 },
+    ])
+    mockSendToConnection.mockResolvedValue(undefined)
+
+    const result = (await handler(
+      createEvent('conn-1', { action: 'webrtc_offer', data: { roomId: 'room-1', sdp: 'v=0...' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(200)
+    expect(mockSendToConnection).toHaveBeenCalledOnce()
+    expect(mockSendToConnection).toHaveBeenCalledWith('conn-2', {
+      type: 'webrtc_offer',
+      data: { sdp: 'v=0...' },
+    })
+  })
+
+  it('should return 400 for invalid body', async () => {
+    const result = (await handler(
+      createEvent('conn-1', { action: 'webrtc_offer', data: { roomId: 'room-1' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('should return 500 on error', async () => {
+    mockQueryConnectionsByRoomId.mockRejectedValueOnce(new Error('fail'))
+
+    const result = (await handler(
+      createEvent('conn-1', { action: 'webrtc_offer', data: { roomId: 'room-1', sdp: 'v=0...' } }),
+      mockContext,
+      noop,
+    )) as APIGatewayProxyResult
+
+    expect(result.statusCode).toBe(500)
+  })
+})

--- a/src/functions/ws-webrtc-offer/handler.ts
+++ b/src/functions/ws-webrtc-offer/handler.ts
@@ -1,6 +1,35 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
+import { queryConnectionsByRoomId } from '../../lib/dynamodb'
+import { sendToConnection } from '../../lib/websocket'
+import { WebrtcSdpSchema } from '../../utils/validation'
 
-export const handler: APIGatewayProxyHandler = async (_event) => {
-  await Promise.resolve()
-  return { statusCode: 200, body: 'OK' }
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const connectionId = event.requestContext.connectionId
+  if (!connectionId) {
+    return { statusCode: 400, body: 'Missing connectionId' }
+  }
+
+  try {
+    const body = JSON.parse(event.body ?? '{}') as Record<string, unknown>
+    const parsed = WebrtcSdpSchema.safeParse(body.data)
+    if (!parsed.success) {
+      return { statusCode: 400, body: parsed.error.message }
+    }
+
+    const connections = await queryConnectionsByRoomId(parsed.data.roomId)
+    const others = connections.filter((c) => c.connectionId !== connectionId)
+
+    await Promise.all(
+      others.map((c) =>
+        sendToConnection(c.connectionId, {
+          type: 'webrtc_offer',
+          data: { sdp: parsed.data.sdp },
+        }),
+      ),
+    )
+
+    return { statusCode: 200, body: 'OK' }
+  } catch {
+    return { statusCode: 500, body: 'Internal server error' }
+  }
 }


### PR DESCRIPTION
## Summary
- `ws-join-room`: ルーム参加（connectionId に roomId + role を紐付け）(4テスト)
- `ws-webrtc-offer`: SDP Offer を同一 roomId の相手に転送 (3テスト)
- `ws-webrtc-answer`: SDP Answer を同一 roomId の相手に転送 (2テスト)
- `ws-webrtc-ice`: ICE Candidate を同一 roomId の相手に転送 (2テスト)
- `ws-shooting-sync`: 撮影同期イベントを同一 roomId の相手に転送 (4テスト)

## Test plan
- [x] 100 テスト全パス (`npm run test`)
- [x] ESLint パス (`npm run lint`)
- [x] 型チェックパス (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)