### PR TITLE
feat: filter-apply Lambda 実装

### DIFF
--- a/src/functions/filter-apply/handler.test.ts
+++ b/src/functions/filter-apply/handler.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockGetObject, mockPutObject } = vi.hoisted(() => ({
+  mockGetObject: vi.fn(),
+  mockPutObject: vi.fn(),
+}))
+
+const { mockSharp, mockSharpInstance } = vi.hoisted(() => {
+  const instance = {
+    blur: vi.fn().mockReturnThis(),
+    sharpen: vi.fn().mockReturnThis(),
+    modulate: vi.fn().mockReturnThis(),
+    linear: vi.fn().mockReturnThis(),
+    greyscale: vi.fn().mockReturnThis(),
+    tint: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from([1, 2, 3])),
+  }
+  return { mockSharpInstance: instance, mockSharp: vi.fn(() => instance) }
+})
+
+vi.mock('../../lib/s3', () => ({
+  getObject: (...args: unknown[]) => mockGetObject(...args) as unknown,
+  putObject: (...args: unknown[]) => mockPutObject(...args) as unknown,
+}))
+
+vi.mock('sharp', () => ({ default: mockSharp }))
+
+import { handler } from './handler'
+import type { PipelineInput } from '../../lib/types'
+
+const baseInput: PipelineInput = {
+  sessionId: 'test-uuid',
+  filterType: 'simple',
+  filter: 'beauty',
+  images: ['originals/test-uuid/1.jpg', 'originals/test-uuid/2.jpg'],
+  bucket: 'test-bucket',
+}
+
+describe('filter-apply handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetObject.mockResolvedValue(Buffer.from([255, 0, 0]))
+    mockPutObject.mockResolvedValue(undefined)
+  })
+
+  it('should apply beauty filter and save filtered images', async () => {
+    const result = await handler(baseInput)
+
+    expect(mockGetObject).toHaveBeenCalledTimes(2)
+    expect(mockPutObject).toHaveBeenCalledTimes(2)
+    expect(mockSharpInstance.blur).toHaveBeenCalled()
+    expect(mockSharpInstance.sharpen).toHaveBeenCalled()
+    expect(result.filteredImages).toHaveLength(2)
+  })
+
+  it('should apply mono filter', async () => {
+    const result = await handler({ ...baseInput, filter: 'mono' })
+
+    expect(mockSharpInstance.greyscale).toHaveBeenCalled()
+    expect(result.filteredImages).toHaveLength(2)
+  })
+
+  it('should apply sepia filter', async () => {
+    await handler({ ...baseInput, filter: 'sepia' })
+
+    expect(mockSharpInstance.greyscale).toHaveBeenCalled()
+    expect(mockSharpInstance.tint).toHaveBeenCalled()
+  })
+
+  it('should apply bright filter', async () => {
+    await handler({ ...baseInput, filter: 'bright' })
+
+    expect(mockSharpInstance.modulate).toHaveBeenCalledWith({ brightness: 1.2 })
+    expect(mockSharpInstance.linear).toHaveBeenCalledWith(1.1, 0)
+  })
+
+  it('should pass through natural filter without processing', async () => {
+    await handler({ ...baseInput, filter: 'natural' })
+
+    expect(mockSharpInstance.blur).not.toHaveBeenCalled()
+    expect(mockSharpInstance.greyscale).not.toHaveBeenCalled()
+    expect(mockSharpInstance.modulate).not.toHaveBeenCalled()
+    expect(mockSharpInstance.png).toHaveBeenCalled()
+  })
+
+  it('should return filteredImages keys in result', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.filteredImages).toEqual([
+      'filtered/test-uuid/1.png',
+      'filtered/test-uuid/2.png',
+    ])
+  })
+
+  it('should propagate input fields in result', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.sessionId).toBe('test-uuid')
+    expect(result.bucket).toBe('test-bucket')
+  })
+})

--- a/src/functions/filter-apply/handler.ts
+++ b/src/functions/filter-apply/handler.ts
@@ -1,4 +1,44 @@
-export const handler = async (_event: Record<string, unknown>): Promise<Record<string, unknown>> => {
-  await Promise.resolve()
-  return { ..._event, status: 'TODO: implement' }
+import sharp from 'sharp'
+import { getObject, putObject } from '../../lib/s3'
+import type { PipelineInput, Filter } from '../../lib/types'
+
+interface FilterApplyOutput extends PipelineInput {
+  readonly filteredImages: readonly string[]
+}
+
+const applyFilter = (pipeline: sharp.Sharp, filter: Filter): sharp.Sharp => {
+  switch (filter) {
+    case 'natural':
+      return pipeline
+    case 'beauty':
+      return pipeline.blur(1.5).sharpen()
+    case 'bright':
+      return pipeline.modulate({ brightness: 1.2 }).linear(1.1, 0)
+    case 'mono':
+      return pipeline.greyscale()
+    case 'sepia':
+      return pipeline.greyscale().tint({ r: 112, g: 66, b: 20 })
+    case 'anime':
+    case 'popart':
+    case 'watercolor':
+      return pipeline
+  }
+}
+
+export const handler = async (event: PipelineInput): Promise<FilterApplyOutput> => {
+  const { sessionId, filter, images } = event
+
+  const filteredImages = await Promise.all(
+    images.map(async (imageKey, i) => {
+      const imageBuffer = await getObject(imageKey)
+      const pipeline = applyFilter(sharp(imageBuffer), filter)
+      const outputBuffer = await pipeline.png().toBuffer()
+
+      const outputKey = `filtered/${sessionId}/${String(i + 1)}.png`
+      await putObject(outputKey, outputBuffer)
+      return outputKey
+    }),
+  )
+
+  return { ...event, filteredImages }
 }


### PR DESCRIPTION
## Summary
- S3 から元画像を取得し、sharp で5種の簡易フィルターを適用
  - natural (パススルー), beauty (blur+sharpen), bright (明るさ+コントラスト), mono (グレースケール), sepia
- AI フィルター (anime/popart/watercolor) はパススルーで Stage 3.5 で実装
- フィルター済み画像を `filtered/{sessionId}/{n}.png` に保存
- 7テスト追加

## Test plan
- [x] 7 テスト全パス
- [x] ESLint パス
- [x] 型チェックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)