### PR TITLE
feat: collage-generate Lambda 実装

### DIFF
--- a/src/functions/collage-generate/handler.test.ts
+++ b/src/functions/collage-generate/handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockGetObject, mockPutObject } = vi.hoisted(() => ({
+  mockGetObject: vi.fn(),
+  mockPutObject: vi.fn(),
+}))
+
+const { mockSharp, mockSharpInstance } = vi.hoisted(() => {
+  const instance = {
+    resize: vi.fn().mockReturnThis(),
+    extract: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    composite: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from([1, 2, 3])),
+    metadata: vi.fn().mockResolvedValue({ width: 800, height: 600 }),
+  }
+  return { mockSharpInstance: instance, mockSharp: vi.fn(() => instance) }
+})
+
+vi.mock('../../lib/s3', () => ({
+  getObject: (...args: unknown[]) => mockGetObject(...args) as unknown,
+  putObject: (...args: unknown[]) => mockPutObject(...args) as unknown,
+}))
+
+vi.mock('sharp', () => ({ default: mockSharp }))
+
+import { handler } from './handler'
+
+const baseInput = {
+  sessionId: 'test-uuid',
+  filterType: 'simple' as const,
+  filter: 'beauty' as const,
+  images: ['originals/test-uuid/1.jpg', 'originals/test-uuid/2.jpg'],
+  bucket: 'test-bucket',
+  filteredImages: [
+    'filtered/test-uuid/1.png',
+    'filtered/test-uuid/2.png',
+    'filtered/test-uuid/3.png',
+    'filtered/test-uuid/4.png',
+  ],
+}
+
+describe('collage-generate handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetObject.mockResolvedValue(Buffer.from([1, 2, 3]))
+    mockPutObject.mockResolvedValue(undefined)
+  })
+
+  it('should generate collage and save to S3', async () => {
+    const result = await handler(baseInput)
+
+    expect(mockGetObject).toHaveBeenCalledTimes(4)
+    expect(mockPutObject).toHaveBeenCalledOnce()
+    expect(result.collageKey).toBe('collages/test-uuid.png')
+  })
+
+  it('should create canvas with sharp and composite 4 images', async () => {
+    await handler(baseInput)
+
+    // Canvas creation: sharp with create option
+    const firstCall = mockSharp.mock.calls as unknown[][]
+    const canvasCall = firstCall.find(
+      (call) => typeof call[0] === 'object' && 'create' in (call[0] as Record<string, unknown>),
+    )
+    expect(canvasCall).toBeDefined()
+
+    // Composite should be called with 4 images
+    expect(mockSharpInstance.composite).toHaveBeenCalledOnce()
+  })
+
+  it('should propagate input fields in result', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.sessionId).toBe('test-uuid')
+    expect(result.bucket).toBe('test-bucket')
+    expect(result.filteredImages).toEqual(baseInput.filteredImages)
+  })
+
+  it('should crop images to square before compositing', async () => {
+    await handler(baseInput)
+
+    // Each filtered image gets resized
+    expect(mockSharpInstance.resize).toHaveBeenCalled()
+  })
+})

--- a/src/functions/collage-generate/handler.ts
+++ b/src/functions/collage-generate/handler.ts
@@ -1,4 +1,79 @@
-export const handler = async (_event: Record<string, unknown>): Promise<Record<string, unknown>> => {
-  await Promise.resolve()
-  return { ..._event, status: 'TODO: implement' }
+import sharp from 'sharp'
+import { getObject, putObject } from '../../lib/s3'
+import type { PipelineInput } from '../../lib/types'
+
+interface CollageInput extends PipelineInput {
+  readonly filteredImages: readonly string[]
+}
+
+interface CollageOutput extends CollageInput {
+  readonly collageKey: string
+}
+
+const CANVAS_SIZE = 576
+const PADDING = 10
+const GAP = 6
+
+const CELL_SIZE = Math.floor((CANVAS_SIZE - PADDING * 2 - GAP) / 2)
+
+const cropToSquare = async (buffer: Buffer): Promise<Buffer> => {
+  const image = sharp(buffer)
+  const { width, height } = await image.metadata()
+  const size = Math.min(width, height)
+
+  return image
+    .extract({
+      left: Math.floor((width - size) / 2),
+      top: Math.floor((height - size) / 2),
+      width: size,
+      height: size,
+    })
+    .resize(CELL_SIZE, CELL_SIZE)
+    .toBuffer()
+}
+
+export const handler = async (event: CollageInput): Promise<CollageOutput> => {
+  const { sessionId, filteredImages } = event
+
+  const cellBuffers = await Promise.all(
+    filteredImages.map(async (key) => {
+      const buffer = await getObject(key)
+      return cropToSquare(buffer)
+    }),
+  )
+
+  const positions: readonly [
+    { left: number; top: number },
+    { left: number; top: number },
+    { left: number; top: number },
+    { left: number; top: number },
+  ] = [
+    { left: PADDING, top: PADDING },
+    { left: PADDING + CELL_SIZE + GAP, top: PADDING },
+    { left: PADDING, top: PADDING + CELL_SIZE + GAP },
+    { left: PADDING + CELL_SIZE + GAP, top: PADDING + CELL_SIZE + GAP },
+  ]
+
+  const compositeInputs = [
+    { input: cellBuffers[0], left: positions[0].left, top: positions[0].top },
+    { input: cellBuffers[1], left: positions[1].left, top: positions[1].top },
+    { input: cellBuffers[2], left: positions[2].left, top: positions[2].top },
+    { input: cellBuffers[3], left: positions[3].left, top: positions[3].top },
+  ]
+
+  const canvas = sharp({
+    create: {
+      width: CANVAS_SIZE,
+      height: CANVAS_SIZE,
+      channels: 3 as const,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+
+  const collageBuffer = await canvas.composite(compositeInputs).png().toBuffer()
+
+  const collageKey = `collages/${sessionId}.png`
+  await putObject(collageKey, collageBuffer)
+
+  return { ...event, collageKey }
 }


### PR DESCRIPTION
## Summary
- フィルター済み4枚を S3 から取得し、576x576px の 2x2 グリッドに合成
- 正方形クロップ → リサイズ → composite で配置 (padding 10px, gap 6px)
- コラージュを `collages/{sessionId}.png` に保存
- 4テスト追加

## Test plan
- [x] テスト全パス
- [x] ESLint パス
- [x] 型チェックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)