### PR TITLE
feat: print-prepare Lambda 実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@eslint/js": "^10.0.1",
         "@types/aws-lambda": "^8.10.161",
         "@types/node": "^25.3.5",
+        "@types/qrcode": "^1.5.6",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
@@ -3483,6 +3484,16 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@eslint/js": "^10.0.1",
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "^25.3.5",
+    "@types/qrcode": "^1.5.6",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",

--- a/src/functions/print-prepare/handler.test.ts
+++ b/src/functions/print-prepare/handler.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockGetObject, mockPutObject } = vi.hoisted(() => ({
+  mockGetObject: vi.fn(),
+  mockPutObject: vi.fn(),
+}))
+
+const { mockSharp } = vi.hoisted(() => {
+  const rawData = new Uint8Array(576 * 576).fill(128)
+  const instance = {
+    resize: vi.fn().mockReturnThis(),
+    greyscale: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    composite: vi.fn().mockReturnThis(),
+    extend: vi.fn().mockReturnThis(),
+    raw: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from(rawData)),
+    metadata: vi.fn().mockResolvedValue({ width: 576, height: 576 }),
+  }
+  return { _mockSharpInstance: instance, mockSharp: vi.fn(() => instance) }
+})
+
+const { mockQRCodeToBuffer } = vi.hoisted(() => ({
+  mockQRCodeToBuffer: vi.fn().mockResolvedValue(Buffer.from([1, 2, 3])),
+}))
+
+vi.mock('../../lib/s3', () => ({
+  getObject: (...args: unknown[]) => mockGetObject(...args) as unknown,
+  putObject: (...args: unknown[]) => mockPutObject(...args) as unknown,
+}))
+
+vi.mock('sharp', () => ({ default: mockSharp }))
+
+vi.mock('qrcode', () => ({
+  default: {
+    toBuffer: (...args: unknown[]) => mockQRCodeToBuffer(...args) as unknown,
+  },
+  toBuffer: (...args: unknown[]) => mockQRCodeToBuffer(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const baseInput = {
+  sessionId: 'test-uuid',
+  filterType: 'simple' as const,
+  filter: 'beauty' as const,
+  images: ['originals/test-uuid/1.jpg'],
+  bucket: 'test-bucket',
+  filteredImages: ['filtered/test-uuid/1.png'],
+  collageKey: 'collages/test-uuid.png',
+}
+
+describe('print-prepare handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetObject.mockResolvedValue(Buffer.from([1, 2, 3]))
+    mockPutObject.mockResolvedValue(undefined)
+    process.env.DOWNLOAD_DOMAIN = 'https://example.com'
+  })
+
+  it('should save download image and print-ready image', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.downloadKey).toBe('downloads/test-uuid.png')
+    expect(result.printKey).toBe('print-ready/test-uuid.png')
+  })
+
+  it('should save collage as download image', async () => {
+    await handler(baseInput)
+
+    expect(mockPutObject).toHaveBeenCalledWith(
+      'downloads/test-uuid.png',
+      expect.any(Buffer) as Buffer,
+    )
+  })
+
+  it('should generate QR code for download URL', async () => {
+    await handler(baseInput)
+
+    expect(mockQRCodeToBuffer).toHaveBeenCalledWith(
+      'https://example.com/download/test-uuid',
+      expect.objectContaining({ type: 'png' }) as Record<string, unknown>,
+    )
+  })
+
+  it('should create print-ready image with dithering', async () => {
+    await handler(baseInput)
+
+    // Should save print-ready image
+    expect(mockPutObject).toHaveBeenCalledWith(
+      'print-ready/test-uuid.png',
+      expect.any(Buffer) as Buffer,
+    )
+  })
+
+  it('should propagate input fields in result', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.sessionId).toBe('test-uuid')
+    expect(result.collageKey).toBe('collages/test-uuid.png')
+  })
+
+  it('should use default domain when DOWNLOAD_DOMAIN is not set', async () => {
+    delete process.env.DOWNLOAD_DOMAIN
+
+    await handler(baseInput)
+
+    expect(mockQRCodeToBuffer).toHaveBeenCalledWith(
+      expect.stringContaining('/download/test-uuid') as string,
+      expect.any(Object) as Record<string, unknown>,
+    )
+  })
+})

--- a/src/functions/print-prepare/handler.ts
+++ b/src/functions/print-prepare/handler.ts
@@ -1,4 +1,107 @@
-export const handler = async (_event: Record<string, unknown>): Promise<Record<string, unknown>> => {
-  await Promise.resolve()
-  return { ..._event, status: 'TODO: implement' }
+import sharp from 'sharp'
+import QRCode from 'qrcode'
+import { getObject, putObject } from '../../lib/s3'
+import type { PipelineInput } from '../../lib/types'
+
+interface PrintPrepareInput extends PipelineInput {
+  readonly filteredImages: readonly string[]
+  readonly collageKey: string
+}
+
+interface PrintPrepareOutput extends PrintPrepareInput {
+  readonly downloadKey: string
+  readonly printKey: string
+}
+
+const PRINT_WIDTH = 576
+
+/** Floyd-Steinberg dithering on single-channel greyscale pixel data. */
+const floydSteinbergDither = (pixels: Uint8Array, width: number, height: number): Uint8Array => {
+  const data = new Float32Array(pixels)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by caller
+  const get = (i: number): number => data[i]!
+  const add = (i: number, v: number): void => { data[i] = get(i) + v }
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = y * width + x
+      const oldPixel = get(idx)
+      const newPixel = oldPixel < 128 ? 0 : 255
+      data[idx] = newPixel
+      const err = oldPixel - newPixel
+
+      if (x + 1 < width) add(idx + 1, err * 7 / 16)
+      if (y + 1 < height) {
+        if (x > 0) add((y + 1) * width + (x - 1), err * 3 / 16)
+        add((y + 1) * width + x, err * 5 / 16)
+        if (x + 1 < width) add((y + 1) * width + (x + 1), err * 1 / 16)
+      }
+    }
+  }
+
+  const output = new Uint8Array(width * height)
+  for (let i = 0; i < data.length; i++) {
+    output[i] = Math.max(0, Math.min(255, Math.round(get(i))))
+  }
+  return output
+}
+
+export const handler = async (event: PrintPrepareInput): Promise<PrintPrepareOutput> => {
+  const { sessionId, collageKey } = event
+
+  const collageBuffer = await getObject(collageKey)
+
+  // Save download copy
+  const downloadKey = `downloads/${sessionId}.png`
+  await putObject(downloadKey, collageBuffer)
+
+  // Generate QR code
+  const domain = process.env.DOWNLOAD_DOMAIN ?? 'https://receipt-purikura.example.com'
+  const qrBuffer = await QRCode.toBuffer(`${domain}/download/${sessionId}`, {
+    type: 'png',
+    width: 120,
+    margin: 1,
+  })
+
+  // Build print layout: collage + QR code at bottom
+  const qrComposite = await sharp(collageBuffer)
+    .resize(PRINT_WIDTH, PRINT_WIDTH)
+    .extend({ bottom: 150, background: { r: 255, g: 255, b: 255 } })
+    .composite([
+      {
+        input: await sharp(qrBuffer).resize(120, 120).toBuffer(),
+        left: Math.floor((PRINT_WIDTH - 120) / 2),
+        top: PRINT_WIDTH + 15,
+      },
+    ])
+    .greyscale()
+    .raw()
+    .toBuffer()
+
+  // Get dimensions of the print layout
+  const printMeta = await sharp(collageBuffer)
+    .resize(PRINT_WIDTH, PRINT_WIDTH)
+    .extend({ bottom: 150, background: { r: 255, g: 255, b: 255 } })
+    .metadata()
+  const printHeight = printMeta.height
+  const printWidth = printMeta.width
+
+  // Floyd-Steinberg dithering
+  const dithered = floydSteinbergDither(
+    new Uint8Array(qrComposite),
+    printWidth,
+    printHeight,
+  )
+
+  // Convert back to PNG
+  const printBuffer = await sharp(Buffer.from(dithered), {
+    raw: { width: printWidth, height: printHeight, channels: 1 },
+  })
+    .png()
+    .toBuffer()
+
+  const printKey = `print-ready/${sessionId}.png`
+  await putObject(printKey, printBuffer)
+
+  return { ...event, downloadKey, printKey }
 }


### PR DESCRIPTION
## Summary
- コラージュ画像を `downloads/{sessionId}.png` にコピー（DL用）
- QR コード生成（ダウンロード URL 埋め込み）
- レシートレイアウト合成: コラージュ (576px) + QR コード (120px)
- Floyd-Steinberg ディザリングで白黒2値変換
- 印刷用 PNG を `print-ready/{sessionId}.png` に保存
- 6テスト追加、@types/qrcode 追加

## Test plan
- [x] 117 テスト全パス (`npm run test`)
- [x] ESLint パス (`npm run lint`)
- [x] 型チェックパス (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)