### PR TITLE
feat: face-detection Lambda 実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1010.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1010.0",
+        "@aws-sdk/client-comprehend": "^3.1010.0",
         "@aws-sdk/client-dynamodb": "^3.1010.0",
+        "@aws-sdk/client-rekognition": "^3.1010.0",
         "@aws-sdk/client-s3": "^3.1010.0",
         "@aws-sdk/client-sfn": "^3.1010.0",
         "@aws-sdk/lib-dynamodb": "^3.1010.0",
@@ -285,6 +288,132 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1010.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1010.0.tgz",
+      "integrity": "sha512-+w0fLPL/OjW2SAa7oADu5LmJgbzPTnDCduwcmFnhDUXaeKdyq++BTOX+bqn3SxZ8FnEc8TrfOYAfx66hf7tKdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-node": "^3.972.21",
+        "@aws-sdk/eventstream-handler-node": "^3.972.11",
+        "@aws-sdk/middleware-eventstream": "^3.972.8",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/middleware-websocket": "^3.972.13",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/token-providers": "3.1010.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-stream": "^4.5.19",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1010.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1010.0.tgz",
+      "integrity": "sha512-nR4Iu7+qOUPgnzTpdikOL4cT70R5YRdeo6JQJ5678qv23OwWk3PgJL9BoXtPu2UyAuXNX58BQc7cpYl21sKAoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/nested-clients": "^3.996.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend": {
+      "version": "3.1010.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-comprehend/-/client-comprehend-3.1010.0.tgz",
+      "integrity": "sha512-+fRT+k4TmFnyD5jXIXc2Y9lVTfSwC++ekulKRuBKm3AFihXHnu4HLZJZHp7HbEK4V2oNHlGOKrXsVOTa3GHYIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-node": "^3.972.21",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1010.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1010.0.tgz",
@@ -298,6 +427,57 @@
         "@aws-sdk/credential-provider-node": "^3.972.21",
         "@aws-sdk/dynamodb-codec": "^3.972.21",
         "@aws-sdk/middleware-endpoint-discovery": "^3.972.8",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rekognition": {
+      "version": "3.1010.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rekognition/-/client-rekognition-3.1010.0.tgz",
+      "integrity": "sha512-TFqpFSCtZXkRKVPEUGPtGhF+pu1qljS1GD6gZhsqVdSLhuUQ1lj+ZlHkwPLvpyjM32xyYB/yjzgXxrk0agNPSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-node": "^3.972.21",
         "@aws-sdk/middleware-host-header": "^3.972.8",
         "@aws-sdk/middleware-logger": "^3.972.8",
         "@aws-sdk/middleware-recursion-detection": "^3.972.8",
@@ -680,6 +860,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.11.tgz",
+      "integrity": "sha512-2IrLrOruRr1NhTK0vguBL1gCWv1pu4bf4KaqpsA+/vCJpFEbvXFawn71GvCzk1wyjnDUsemtKypqoKGv4cSGbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/lib-dynamodb": {
       "version": "3.1010.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1010.0.tgz",
@@ -727,6 +922,21 @@
         "@aws-sdk/endpoint-cache": "^3.972.4",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+      "integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
@@ -890,6 +1100,29 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.13.tgz",
+      "integrity": "sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
@@ -3481,7 +3714,6 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
   },
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1010.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1010.0",
+    "@aws-sdk/client-comprehend": "^3.1010.0",
     "@aws-sdk/client-dynamodb": "^3.1010.0",
+    "@aws-sdk/client-rekognition": "^3.1010.0",
     "@aws-sdk/client-s3": "^3.1010.0",
     "@aws-sdk/client-sfn": "^3.1010.0",
     "@aws-sdk/lib-dynamodb": "^3.1010.0",

--- a/src/functions/face-detection/handler.test.ts
+++ b/src/functions/face-detection/handler.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockRekognitionSend } = vi.hoisted(() => ({
+  mockRekognitionSend: vi.fn(),
+}))
+
+vi.mock('@aws-sdk/client-rekognition', () => ({
+  RekognitionClient: class {
+    send = mockRekognitionSend
+  },
+  DetectFacesCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
+
+import { handler } from './handler'
+import type { PipelineInput } from '../../lib/types'
+
+const baseInput: PipelineInput = {
+  sessionId: 'test-uuid',
+  filterType: 'simple',
+  filter: 'beauty',
+  images: ['originals/test-uuid/1.jpg', 'originals/test-uuid/2.jpg'],
+  bucket: 'test-bucket',
+}
+
+const mockFaceDetail = {
+  BoundingBox: { Width: 0.3, Height: 0.4, Left: 0.2, Top: 0.1 },
+  Emotions: [
+    { Type: 'HAPPY', Confidence: 95.5 },
+    { Type: 'CALM', Confidence: 3.2 },
+  ],
+  Confidence: 99.8,
+}
+
+describe('face-detection handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should detect faces in all images', async () => {
+    mockRekognitionSend.mockResolvedValue({
+      FaceDetails: [mockFaceDetail],
+    })
+
+    const result = await handler(baseInput)
+
+    expect(mockRekognitionSend).toHaveBeenCalledTimes(2)
+    expect(result.faces).toHaveLength(2)
+  })
+
+  it('should return face bounding boxes and emotions', async () => {
+    mockRekognitionSend.mockResolvedValue({
+      FaceDetails: [mockFaceDetail],
+    })
+
+    const result = await handler(baseInput)
+    const firstImage = result.faces[0] as { imageKey: string; details: readonly unknown[] }
+
+    expect(firstImage.imageKey).toBe('originals/test-uuid/1.jpg')
+    expect(firstImage.details).toHaveLength(1)
+  })
+
+  it('should handle images with no faces', async () => {
+    mockRekognitionSend.mockResolvedValue({
+      FaceDetails: [],
+    })
+
+    const result = await handler(baseInput)
+    const firstImage = result.faces[0] as { details: readonly unknown[] }
+
+    expect(firstImage.details).toHaveLength(0)
+  })
+
+  it('should propagate input fields', async () => {
+    mockRekognitionSend.mockResolvedValue({ FaceDetails: [] })
+
+    const result = await handler(baseInput)
+
+    expect(result.sessionId).toBe('test-uuid')
+    expect(result.bucket).toBe('test-bucket')
+  })
+
+  it('should handle Rekognition errors gracefully', async () => {
+    mockRekognitionSend.mockRejectedValue(new Error('Rekognition error'))
+
+    await expect(handler(baseInput)).rejects.toThrow('Rekognition error')
+  })
+})

--- a/src/functions/face-detection/handler.ts
+++ b/src/functions/face-detection/handler.ts
@@ -1,4 +1,57 @@
-export const handler = async (_event: Record<string, unknown>): Promise<Record<string, unknown>> => {
-  await Promise.resolve()
-  return { ..._event, status: 'TODO: implement' }
+import { RekognitionClient, DetectFacesCommand } from '@aws-sdk/client-rekognition'
+import type { PipelineInput } from '../../lib/types'
+
+const rekognition = new RekognitionClient({})
+
+interface FaceResult {
+  readonly imageKey: string
+  readonly details: readonly {
+    readonly boundingBox: {
+      readonly width: number
+      readonly height: number
+      readonly left: number
+      readonly top: number
+    }
+    readonly emotions: readonly { readonly type: string; readonly confidence: number }[]
+    readonly confidence: number
+  }[]
+}
+
+interface FaceDetectionOutput extends PipelineInput {
+  readonly faces: readonly FaceResult[]
+}
+
+export const handler = async (event: PipelineInput): Promise<FaceDetectionOutput> => {
+  const { images, bucket } = event
+
+  const faces = await Promise.all(
+    images.map(async (imageKey) => {
+      const response = await rekognition.send(
+        new DetectFacesCommand({
+          Image: {
+            S3Object: { Bucket: bucket, Name: imageKey },
+          },
+          Attributes: ['ALL'],
+        }),
+      )
+
+      const details = (response.FaceDetails ?? []).map((face) => ({
+        boundingBox: {
+          width: face.BoundingBox?.Width ?? 0,
+          height: face.BoundingBox?.Height ?? 0,
+          left: face.BoundingBox?.Left ?? 0,
+          top: face.BoundingBox?.Top ?? 0,
+        },
+        emotions: (face.Emotions ?? []).map((e) => ({
+          type: e.Type ?? 'UNKNOWN',
+          confidence: e.Confidence ?? 0,
+        })),
+        confidence: face.Confidence ?? 0,
+      }))
+
+      return { imageKey, details }
+    }),
+  )
+
+  return { ...event, faces }
 }


### PR DESCRIPTION
## Summary
- Rekognition DetectFaces で4枚並列に顔検出
- バウンディングボックス + 感情ラベル + 信頼度を構造化して返却
- AWS SDK (Rekognition, Bedrock Runtime, Comprehend) 依存追加
- 5テスト追加

## Test plan
- [x] テスト全パス
- [x] ESLint パス
- [x] 型チェックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)