### PR TITLE
feat: caption-generate Lambda 実装

### DIFF
--- a/src/functions/caption-generate/handler.test.ts
+++ b/src/functions/caption-generate/handler.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockBedrockSend, mockComprehendSend, mockGetObject, mockUpdateSession } =
+  vi.hoisted(() => ({
+    mockBedrockSend: vi.fn(),
+    mockComprehendSend: vi.fn(),
+    mockGetObject: vi.fn(),
+    mockUpdateSession: vi.fn(),
+  }))
+
+vi.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: class {
+    send = mockBedrockSend
+  },
+  InvokeModelCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
+
+vi.mock('@aws-sdk/client-comprehend', () => ({
+  ComprehendClient: class {
+    send = mockComprehendSend
+  },
+  DetectSentimentCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
+
+vi.mock('../../lib/s3', () => ({
+  getObject: (...args: unknown[]) => mockGetObject(...args) as unknown,
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  updateSession: (...args: unknown[]) => mockUpdateSession(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const baseInput = {
+  sessionId: 'test-uuid',
+  createdAt: '2026-03-16T14:30:00Z',
+  filterType: 'simple' as const,
+  filter: 'beauty' as const,
+  images: ['originals/test-uuid/1.jpg'],
+  bucket: 'test-bucket',
+  filteredImages: ['filtered/test-uuid/1.png'],
+  collageKey: 'collages/test-uuid.png',
+}
+
+describe('caption-generate handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetObject.mockResolvedValue(Buffer.from([1, 2, 3]))
+    mockBedrockSend.mockResolvedValue({
+      body: new TextEncoder().encode(
+        JSON.stringify({
+          content: [{ text: '楽しい思い出の一枚！' }],
+        }),
+      ),
+    })
+    mockComprehendSend.mockResolvedValue({
+      Sentiment: 'POSITIVE',
+      SentimentScore: {
+        Positive: 0.95,
+        Negative: 0.01,
+        Neutral: 0.03,
+        Mixed: 0.01,
+      },
+    })
+    mockUpdateSession.mockResolvedValue(undefined)
+  })
+
+  it('should generate caption and detect sentiment', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.caption).toBe('楽しい思い出の一枚！')
+    expect(result.sentiment).toBe('POSITIVE')
+    expect(result.sentimentScore).toBe(0.95)
+  })
+
+  it('should call Bedrock with collage image', async () => {
+    await handler(baseInput)
+
+    expect(mockBedrockSend).toHaveBeenCalledOnce()
+    expect(mockGetObject).toHaveBeenCalledWith('collages/test-uuid.png')
+  })
+
+  it('should call Comprehend with generated caption', async () => {
+    await handler(baseInput)
+
+    expect(mockComprehendSend).toHaveBeenCalledOnce()
+  })
+
+  it('should update session with caption and sentiment', async () => {
+    await handler(baseInput)
+
+    expect(mockUpdateSession).toHaveBeenCalledWith(
+      'test-uuid',
+      '2026-03-16T14:30:00Z',
+      expect.objectContaining({
+        caption: '楽しい思い出の一枚！',
+        sentiment: 'POSITIVE',
+        sentimentScore: 0.95,
+      }),
+    )
+  })
+
+  it('should propagate input fields', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.sessionId).toBe('test-uuid')
+    expect(result.collageKey).toBe('collages/test-uuid.png')
+  })
+})

--- a/src/functions/caption-generate/handler.ts
+++ b/src/functions/caption-generate/handler.ts
@@ -1,4 +1,90 @@
-export const handler = async (_event: Record<string, unknown>): Promise<Record<string, unknown>> => {
-  await Promise.resolve()
-  return { ..._event, status: 'TODO: implement' }
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
+import { ComprehendClient, DetectSentimentCommand } from '@aws-sdk/client-comprehend'
+import { getObject } from '../../lib/s3'
+import { updateSession } from '../../lib/dynamodb'
+import type { PipelineInput } from '../../lib/types'
+
+const bedrock = new BedrockRuntimeClient({})
+const comprehend = new ComprehendClient({})
+
+interface CaptionInput extends PipelineInput {
+  readonly createdAt: string
+  readonly filteredImages: readonly string[]
+  readonly collageKey: string
+}
+
+interface CaptionOutput extends CaptionInput {
+  readonly caption: string
+  readonly sentiment: string
+  readonly sentimentScore: number
+}
+
+interface BedrockResponse {
+  readonly content: readonly { readonly text: string }[]
+}
+
+export const handler = async (event: CaptionInput): Promise<CaptionOutput> => {
+  const { sessionId, createdAt, collageKey } = event
+
+  // Get collage image for Bedrock
+  const imageBuffer = await getObject(collageKey)
+  const base64Image = imageBuffer.toString('base64')
+
+  // Generate caption with Bedrock Claude
+  const bedrockResponse = await bedrock.send(
+    new InvokeModelCommand({
+      modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({
+        anthropic_version: 'bedrock-2023-05-31',
+        max_tokens: 100,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: base64Image,
+                },
+              },
+              {
+                type: 'text',
+                text: 'この写真に短い日本語キャプションをつけてください。楽しく、ポップな雰囲気で1文でお願いします。',
+              },
+            ],
+          },
+        ],
+      }),
+    }),
+  )
+
+  const bedrockBody = JSON.parse(
+    new TextDecoder().decode(bedrockResponse.body),
+  ) as BedrockResponse
+  const caption = bedrockBody.content[0]?.text ?? ''
+
+  // Sentiment analysis with Comprehend
+  const sentimentResponse = await comprehend.send(
+    new DetectSentimentCommand({
+      Text: caption,
+      LanguageCode: 'ja',
+    }),
+  )
+
+  const sentiment = sentimentResponse.Sentiment ?? 'NEUTRAL'
+  const scores = sentimentResponse.SentimentScore
+  const sentimentScore = scores?.Positive ?? 0
+
+  // Update session
+  await updateSession(sessionId, createdAt, {
+    caption,
+    sentiment,
+    sentimentScore,
+  })
+
+  return { ...event, caption, sentiment, sentimentScore }
 }


### PR DESCRIPTION
## Summary
- Bedrock Claude Haiku でコラージュ画像からキャプション自動生成
- Comprehend で感情分析 (DetectSentiment)
- DynamoDB にキャプション + 感情スコアを保存
- 5テスト追加

## Test plan
- [x] テスト全パス
- [x] ESLint パス
- [x] 型チェックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)