### PR TITLE
feat: yaji-comment-fast/deep + stats-update 実装

### DIFF
--- a/src/functions/stats-update/handler.test.ts
+++ b/src/functions/stats-update/handler.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockDocClientSend } = vi.hoisted(() => ({
+  mockDocClientSend: vi.fn(),
+}))
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+  DynamoDBClient: class {},
+}))
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: () => ({ send: mockDocClientSend }),
+  },
+  UpdateCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
+
+import { handler } from './handler'
+import type { DynamoDBStreamEvent, Context } from 'aws-lambda'
+
+const mockContext = {} as Context
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {}
+
+const createStreamEvent = (eventName: 'INSERT' | 'MODIFY' | 'REMOVE'): DynamoDBStreamEvent => ({
+  Records: [
+    {
+      eventName,
+      dynamodb: {
+        NewImage: {
+          sessionId: { S: 'test-uuid' },
+          status: { S: 'completed' },
+        },
+      },
+    },
+  ],
+})
+
+describe('stats-update handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.STATS_TABLE = 'test-stats'
+    mockDocClientSend.mockResolvedValue(undefined)
+  })
+
+  it('should increment counter on INSERT', async () => {
+    await handler(createStreamEvent('INSERT'), mockContext, noop)
+
+    expect(mockDocClientSend).toHaveBeenCalledOnce()
+  })
+
+  it('should update counter on MODIFY', async () => {
+    await handler(createStreamEvent('MODIFY'), mockContext, noop)
+
+    expect(mockDocClientSend).toHaveBeenCalledOnce()
+  })
+
+  it('should skip REMOVE events', async () => {
+    await handler(createStreamEvent('REMOVE'), mockContext, noop)
+
+    expect(mockDocClientSend).not.toHaveBeenCalled()
+  })
+
+  it('should handle empty records', async () => {
+    await handler({ Records: [] }, mockContext, noop)
+
+    expect(mockDocClientSend).not.toHaveBeenCalled()
+  })
+})

--- a/src/functions/stats-update/handler.ts
+++ b/src/functions/stats-update/handler.ts
@@ -1,6 +1,29 @@
 import type { DynamoDBStreamHandler } from 'aws-lambda'
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 
-export const handler: DynamoDBStreamHandler = async (_event) => {
-  await Promise.resolve()
-  // TODO: implement stats update
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+
+export const handler: DynamoDBStreamHandler = async (event) => {
+  const tableName = process.env.STATS_TABLE
+  if (!tableName) return
+
+  for (const record of event.Records) {
+    if (record.eventName === 'REMOVE') continue
+
+    const status = record.dynamodb?.NewImage?.status?.S ?? 'unknown'
+    const today = new Date().toISOString().slice(0, 10)
+
+    await docClient.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { date: today },
+        UpdateExpression:
+          'SET totalSessions = if_not_exists(totalSessions, :zero) + :one, ' +
+          `#status = if_not_exists(#status, :zero) + :one`,
+        ExpressionAttributeNames: { '#status': status },
+        ExpressionAttributeValues: { ':zero': 0, ':one': 1 },
+      }),
+    )
+  }
 }

--- a/src/functions/yaji-comment-deep/handler.test.ts
+++ b/src/functions/yaji-comment-deep/handler.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockBedrockSend, mockGetObject, mockSendToSession } = vi.hoisted(() => ({
+  mockBedrockSend: vi.fn(),
+  mockGetObject: vi.fn(),
+  mockSendToSession: vi.fn(),
+}))
+
+vi.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: class {
+    send = mockBedrockSend
+  },
+  InvokeModelCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
+
+vi.mock('../../lib/s3', () => ({
+  getObject: (...args: unknown[]) => mockGetObject(...args) as unknown,
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToSession: (...args: unknown[]) => mockSendToSession(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const baseInput = {
+  sessionId: 'test-uuid',
+  bucket: 'test-bucket',
+  images: ['originals/test-uuid/1.jpg'],
+}
+
+describe('yaji-comment-deep handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetObject.mockResolvedValue(Buffer.from([1, 2, 3]))
+    mockSendToSession.mockResolvedValue(undefined)
+    mockBedrockSend.mockResolvedValue({
+      body: new TextEncoder().encode(
+        JSON.stringify({
+          content: [{ text: 'めっちゃ楽しそうやんｗｗ' }],
+        }),
+      ),
+    })
+  })
+
+  it('should generate deep comment via Bedrock and send via WebSocket', async () => {
+    const result = await handler(baseInput)
+
+    expect(mockBedrockSend).toHaveBeenCalledOnce()
+    expect(mockSendToSession).toHaveBeenCalledWith(
+      'test-uuid',
+      expect.objectContaining({
+        type: 'yajiComment',
+        data: expect.objectContaining({
+          text: 'めっちゃ楽しそうやんｗｗ',
+          lane: 'deep',
+        }) as Record<string, unknown>,
+      }),
+    )
+    expect(result.sessionId).toBe('test-uuid')
+  })
+
+  it('should read first image from S3', async () => {
+    await handler(baseInput)
+
+    expect(mockGetObject).toHaveBeenCalledWith('originals/test-uuid/1.jpg')
+  })
+
+  it('should propagate input', async () => {
+    const result = await handler(baseInput)
+
+    expect(result.bucket).toBe('test-bucket')
+  })
+})

--- a/src/functions/yaji-comment-deep/handler.ts
+++ b/src/functions/yaji-comment-deep/handler.ts
@@ -1,4 +1,75 @@
-export const handler = async (_event: Record<string, unknown>): Promise<Record<string, unknown>> => {
-  await Promise.resolve()
-  return { ..._event, status: 'TODO: implement' }
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
+import { getObject } from '../../lib/s3'
+import { sendToSession } from '../../lib/websocket'
+
+const bedrock = new BedrockRuntimeClient({})
+
+interface YajiInput {
+  readonly sessionId: string
+  readonly bucket: string
+  readonly images: readonly string[]
+}
+
+interface BedrockResponse {
+  readonly content: readonly { readonly text: string }[]
+}
+
+export const handler = async (event: YajiInput): Promise<YajiInput> => {
+  const { sessionId, images } = event
+
+  const firstImage = images[0]
+  if (!firstImage) return event
+
+  const imageBuffer = await getObject(firstImage)
+  const base64Image = imageBuffer.toString('base64')
+
+  const response = await bedrock.send(
+    new InvokeModelCommand({
+      modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({
+        anthropic_version: 'bedrock-2023-05-31',
+        max_tokens: 50,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/jpeg',
+                  data: base64Image,
+                },
+              },
+              {
+                type: 'text',
+                text: 'この写真の人にニコニコ動画風のやじコメントを1つだけ書いてください。短く面白く、ネットスラング可。',
+              },
+            ],
+          },
+        ],
+      }),
+    }),
+  )
+
+  const body = JSON.parse(
+    new TextDecoder().decode(response.body),
+  ) as BedrockResponse
+  const text = body.content[0]?.text ?? ''
+
+  if (text) {
+    await sendToSession(sessionId, {
+      type: 'yajiComment',
+      data: {
+        text,
+        emotion: 'deep',
+        lane: 'deep',
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    })
+  }
+
+  return event
 }

--- a/src/functions/yaji-comment-fast/handler.test.ts
+++ b/src/functions/yaji-comment-fast/handler.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockRekognitionSend, mockSendToSession } = vi.hoisted(() => ({
+  mockRekognitionSend: vi.fn(),
+  mockSendToSession: vi.fn(),
+}))
+
+vi.mock('@aws-sdk/client-rekognition', () => ({
+  RekognitionClient: class {
+    send = mockRekognitionSend
+  },
+  DetectFacesCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToSession: (...args: unknown[]) => mockSendToSession(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+const baseInput = {
+  sessionId: 'test-uuid',
+  bucket: 'test-bucket',
+  images: ['originals/test-uuid/1.jpg'],
+}
+
+describe('yaji-comment-fast handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendToSession.mockResolvedValue(undefined)
+  })
+
+  it('should detect emotions and send template comment', async () => {
+    mockRekognitionSend.mockResolvedValue({
+      FaceDetails: [
+        {
+          Emotions: [
+            { Type: 'HAPPY', Confidence: 95 },
+            { Type: 'CALM', Confidence: 3 },
+          ],
+        },
+      ],
+    })
+
+    const result = await handler(baseInput)
+
+    expect(mockSendToSession).toHaveBeenCalledWith(
+      'test-uuid',
+      expect.objectContaining({
+        type: 'yajiComment',
+        data: expect.objectContaining({
+          lane: 'fast',
+          emotion: 'HAPPY',
+        }) as Record<string, unknown>,
+      }),
+    )
+    expect(result.sessionId).toBe('test-uuid')
+  })
+
+  it('should handle no faces detected', async () => {
+    mockRekognitionSend.mockResolvedValue({ FaceDetails: [] })
+
+    const result = await handler(baseInput)
+
+    expect(mockSendToSession).not.toHaveBeenCalled()
+    expect(result.sessionId).toBe('test-uuid')
+  })
+
+  it('should use first image for detection', async () => {
+    mockRekognitionSend.mockResolvedValue({ FaceDetails: [] })
+
+    await handler(baseInput)
+
+    expect(mockRekognitionSend).toHaveBeenCalledOnce()
+  })
+})

--- a/src/functions/yaji-comment-fast/handler.ts
+++ b/src/functions/yaji-comment-fast/handler.ts
@@ -1,4 +1,62 @@
-export const handler = async (_event: Record<string, unknown>): Promise<Record<string, unknown>> => {
-  await Promise.resolve()
-  return { ..._event, status: 'TODO: implement' }
+import { RekognitionClient, DetectFacesCommand } from '@aws-sdk/client-rekognition'
+import { sendToSession } from '../../lib/websocket'
+
+const rekognition = new RekognitionClient({})
+
+const EMOTION_TEMPLATES: Record<string, readonly string[]> = {
+  HAPPY: ['いい笑顔ｗｗｗ', '楽しそう！', 'ニコニコだね😊', 'ハッピーオーラ全開！'],
+  SAD: ['泣かないで…', 'どうしたの？', '元気出して！'],
+  ANGRY: ['怒ってる？ｗ', 'こわいこわい', '落ち着いてｗ'],
+  CONFUSED: ['困ってる？ｗ', '何があった？', '大丈夫？'],
+  DISGUSTED: ['その顔ｗｗ', 'どうしたのｗ'],
+  SURPRISED: ['びっくり！', 'マジか！', 'えっ！？'],
+  CALM: ['落ち着いてるね', 'クールだね', '余裕の表情'],
+  FEAR: ['こわい？', 'だいじょうぶ！', 'びびってる？ｗ'],
+}
+
+interface YajiInput {
+  readonly sessionId: string
+  readonly bucket: string
+  readonly images: readonly string[]
+}
+
+export const handler = async (event: YajiInput): Promise<YajiInput> => {
+  const { sessionId, bucket, images } = event
+
+  const firstImage = images[0]
+  if (!firstImage) return event
+
+  const response = await rekognition.send(
+    new DetectFacesCommand({
+      Image: { S3Object: { Bucket: bucket, Name: firstImage } },
+      Attributes: ['ALL'],
+    }),
+  )
+
+  const faces = response.FaceDetails ?? []
+  if (faces.length === 0) return event
+
+  const topEmotion = faces[0]?.Emotions?.sort(
+    (a, b) => (b.Confidence ?? 0) - (a.Confidence ?? 0),
+  )[0]
+
+  if (!topEmotion?.Type) return event
+
+  const templates = EMOTION_TEMPLATES[topEmotion.Type] ?? EMOTION_TEMPLATES.CALM
+  if (!templates || templates.length === 0) return event
+
+  const text = templates[Math.floor(Math.random() * templates.length)]
+  if (!text) return event
+
+  await sendToSession(sessionId, {
+    type: 'yajiComment',
+    data: {
+      text,
+      emotion: topEmotion.Type,
+      lane: 'fast',
+      timestamp: Math.floor(Date.now() / 1000),
+    },
+  })
+
+  return event
 }


### PR DESCRIPTION
## Summary
- `yaji-comment-fast`: Rekognition で感情検出 → テンプレートマッチング → WebSocket 配信 (3テスト)
- `yaji-comment-deep`: Bedrock Claude Haiku でマルチモーダル分析 → ニコ動風やじコメント → WebSocket 配信 (3テスト)
- `stats-update`: DynamoDB Streams → 日別セッション統計を集計 (4テスト)

## Test plan
- [x] 137 テスト全パス (`npm run test`)
- [x] ESLint パス (`npm run lint`)
- [x] 型チェックパス (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)