### PR TITLE
feat: collage-generate 可変枚数対応 (1-4枚)

### DIFF
--- a/src/functions/collage-generate/handler.test.ts
+++ b/src/functions/collage-generate/handler.test.ts
@@ -83,4 +83,39 @@ describe('collage-generate handler', () => {
     // Each filtered image gets resized
     expect(mockSharpInstance.resize).toHaveBeenCalled()
   })
+
+  it('should handle 1 image', async () => {
+    const result = await handler({
+      ...baseInput,
+      filteredImages: ['filtered/test-uuid/1.png'],
+    })
+
+    expect(mockGetObject).toHaveBeenCalledTimes(1)
+    expect(mockSharpInstance.composite).toHaveBeenCalledOnce()
+    expect(result.collageKey).toBe('collages/test-uuid.png')
+  })
+
+  it('should handle 2 images', async () => {
+    const result = await handler({
+      ...baseInput,
+      filteredImages: ['filtered/test-uuid/1.png', 'filtered/test-uuid/2.png'],
+    })
+
+    expect(mockGetObject).toHaveBeenCalledTimes(2)
+    expect(result.collageKey).toBe('collages/test-uuid.png')
+  })
+
+  it('should handle 3 images', async () => {
+    const result = await handler({
+      ...baseInput,
+      filteredImages: [
+        'filtered/test-uuid/1.png',
+        'filtered/test-uuid/2.png',
+        'filtered/test-uuid/3.png',
+      ],
+    })
+
+    expect(mockGetObject).toHaveBeenCalledTimes(3)
+    expect(result.collageKey).toBe('collages/test-uuid.png')
+  })
 })

--- a/src/functions/collage-generate/handler.ts
+++ b/src/functions/collage-generate/handler.ts
@@ -14,52 +14,79 @@ const CANVAS_SIZE = 576
 const PADDING = 10
 const GAP = 6
 
-const CELL_SIZE = Math.floor((CANVAS_SIZE - PADDING * 2 - GAP) / 2)
+const CELL_SIZE_2x2 = Math.floor((CANVAS_SIZE - PADDING * 2 - GAP) / 2)
 
-const cropToSquare = async (buffer: Buffer): Promise<Buffer> => {
+const cropToSquare = async (buffer: Buffer, cellSize: number): Promise<Buffer> => {
   const image = sharp(buffer)
-  const { width, height } = await image.metadata()
-  const size = Math.min(width, height)
+  const { width: w, height: h } = await image.metadata()
+  const size = Math.min(w, h)
 
   return image
     .extract({
-      left: Math.floor((width - size) / 2),
-      top: Math.floor((height - size) / 2),
+      left: Math.floor((w - size) / 2),
+      top: Math.floor((h - size) / 2),
       width: size,
       height: size,
     })
-    .resize(CELL_SIZE, CELL_SIZE)
+    .resize(cellSize, cellSize)
     .toBuffer()
+}
+
+/** Get grid positions for 1-4 images. */
+const getLayout = (count: number): { cellSize: number; positions: { left: number; top: number }[] } => {
+  if (count === 1) {
+    const cellSize = CANVAS_SIZE - PADDING * 2
+    return { cellSize, positions: [{ left: PADDING, top: PADDING }] }
+  }
+  if (count === 2) {
+    return {
+      cellSize: CELL_SIZE_2x2,
+      positions: [
+        { left: PADDING, top: Math.floor((CANVAS_SIZE - CELL_SIZE_2x2) / 2) },
+        { left: PADDING + CELL_SIZE_2x2 + GAP, top: Math.floor((CANVAS_SIZE - CELL_SIZE_2x2) / 2) },
+      ],
+    }
+  }
+  if (count === 3) {
+    return {
+      cellSize: CELL_SIZE_2x2,
+      positions: [
+        { left: Math.floor((CANVAS_SIZE - CELL_SIZE_2x2) / 2), top: PADDING },
+        { left: PADDING, top: PADDING + CELL_SIZE_2x2 + GAP },
+        { left: PADDING + CELL_SIZE_2x2 + GAP, top: PADDING + CELL_SIZE_2x2 + GAP },
+      ],
+    }
+  }
+  return {
+    cellSize: CELL_SIZE_2x2,
+    positions: [
+      { left: PADDING, top: PADDING },
+      { left: PADDING + CELL_SIZE_2x2 + GAP, top: PADDING },
+      { left: PADDING, top: PADDING + CELL_SIZE_2x2 + GAP },
+      { left: PADDING + CELL_SIZE_2x2 + GAP, top: PADDING + CELL_SIZE_2x2 + GAP },
+    ],
+  }
 }
 
 export const handler = async (event: CollageInput): Promise<CollageOutput> => {
   const { sessionId, filteredImages } = event
 
+  const { cellSize, positions } = getLayout(filteredImages.length)
+
   const cellBuffers = await Promise.all(
     filteredImages.map(async (key) => {
       const buffer = await getObject(key)
-      return cropToSquare(buffer)
+      return cropToSquare(buffer, cellSize)
     }),
   )
 
-  const positions: readonly [
-    { left: number; top: number },
-    { left: number; top: number },
-    { left: number; top: number },
-    { left: number; top: number },
-  ] = [
-    { left: PADDING, top: PADDING },
-    { left: PADDING + CELL_SIZE + GAP, top: PADDING },
-    { left: PADDING, top: PADDING + CELL_SIZE + GAP },
-    { left: PADDING + CELL_SIZE + GAP, top: PADDING + CELL_SIZE + GAP },
-  ]
-
-  const compositeInputs = [
-    { input: cellBuffers[0], left: positions[0].left, top: positions[0].top },
-    { input: cellBuffers[1], left: positions[1].left, top: positions[1].top },
-    { input: cellBuffers[2], left: positions[2].left, top: positions[2].top },
-    { input: cellBuffers[3], left: positions[3].left, top: positions[3].top },
-  ]
+  const compositeInputs = cellBuffers.map((input, i) => ({
+    input,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    left: positions[i]!.left,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    top: positions[i]!.top,
+  }))
 
   const canvas = sharp({
     create: {


### PR DESCRIPTION
## Summary
- photoCount 1-3枚でクラッシュするバグを修正
- 枚数に応じた動的レイアウト計算 (1枚: フルサイズ, 2枚: 横並び, 3枚: 上1+下2, 4枚: 2x2)
- compositeInputs を動的生成に変更

## Test plan
- [x] `npm run test` — 145 tests passed (1/2/3/4枚のテストケース追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)