### PR TITLE
fix: stats-update 環境変数フォールバック追加

### DIFF
--- a/src/functions/stats-update/handler.test.ts
+++ b/src/functions/stats-update/handler.test.ts
@@ -70,4 +70,22 @@ describe('stats-update handler', () => {
 
     expect(mockDocClientSend).not.toHaveBeenCalled()
   })
+
+  it('should fallback to DYNAMODB_TABLE when STATS_TABLE is not set', async () => {
+    delete process.env.STATS_TABLE
+    process.env.DYNAMODB_TABLE = 'test-sessions'
+
+    await handler(createStreamEvent('INSERT'), mockContext, noop)
+
+    expect(mockDocClientSend).toHaveBeenCalledOnce()
+  })
+
+  it('should skip when neither STATS_TABLE nor DYNAMODB_TABLE is set', async () => {
+    delete process.env.STATS_TABLE
+    delete process.env.DYNAMODB_TABLE
+
+    await handler(createStreamEvent('INSERT'), mockContext, noop)
+
+    expect(mockDocClientSend).not.toHaveBeenCalled()
+  })
 })

--- a/src/functions/stats-update/handler.ts
+++ b/src/functions/stats-update/handler.ts
@@ -5,7 +5,7 @@ import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
 export const handler: DynamoDBStreamHandler = async (event) => {
-  const tableName = process.env.STATS_TABLE
+  const tableName = process.env.STATS_TABLE ?? process.env.DYNAMODB_TABLE
   if (!tableName) return
 
   for (const record of event.Records) {


### PR DESCRIPTION
## Summary
- stats-update が `STATS_TABLE` を参照していたが、CDK は `DYNAMODB_TABLE` を設定していたため実行時に何もしなかった
- `STATS_TABLE ?? DYNAMODB_TABLE` のフォールバックを追加

## Test plan
- [x] `npm run test` — 144 tests passed (フォールバックのテスト2件追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)