### PR TITLE
feat: session-get で Presigned URL 付き collageImageUrl を返す

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -54,8 +54,9 @@ export class AppStack extends cdk.Stack {
     storage.sessionsTable.grantWriteData(api.sessionCreateFn)
     storage.bucket.grantReadWrite(api.sessionCreateFn)
 
-    // session-get: DynamoDB GetItem on sessions
+    // session-get: DynamoDB GetItem on sessions, S3 GetObject for presigned URLs
     storage.sessionsTable.grantReadData(api.sessionGetFn)
+    storage.bucket.grantRead(api.sessionGetFn)
 
     // process-start: Step Functions StartExecution, DynamoDB UpdateItem
     pipeline.stateMachine.grantStartExecution(api.processStartFn)

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -132,6 +132,7 @@ export class Api extends Construct {
       timeout: Duration.seconds(10),
       environment: {
         DYNAMODB_TABLE: sessionsTableName,
+        S3_BUCKET: bucketName,
       },
     }))
 

--- a/src/functions/session-get/handler.test.ts
+++ b/src/functions/session-get/handler.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 
-const { mockGetSession } = vi.hoisted(() => ({
+const { mockGetSession, mockGeneratePresignedDownloadUrl } = vi.hoisted(() => ({
   mockGetSession: vi.fn(),
+  mockGeneratePresignedDownloadUrl: vi.fn(),
 }))
 
 vi.mock('../../lib/dynamodb', () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args) as unknown,
+}))
+
+vi.mock('../../lib/s3', () => ({
+  generatePresignedDownloadUrl: (...args: unknown[]) =>
+    mockGeneratePresignedDownloadUrl(...args) as unknown,
 }))
 
 import { handler } from './handler'
@@ -40,9 +46,36 @@ const invoke = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResul
 describe('session-get handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGeneratePresignedDownloadUrl.mockResolvedValue('https://presigned/download-url')
   })
 
-  it('should return a session when found', async () => {
+  it('should return session with collageImageUrl when downloadKey exists', async () => {
+    const session = {
+      sessionId: 'test-uuid',
+      createdAt: '2026-03-16T14:30:00Z',
+      filterType: 'simple',
+      filter: 'beauty',
+      status: 'completed',
+      photoCount: 4,
+      caption: '楽しい思い出！',
+      downloadKey: 'downloads/test-uuid.png',
+      ttl: 0,
+    }
+    mockGetSession.mockResolvedValueOnce(session)
+
+    const response = await invoke(createEvent('test-uuid'))
+    expect(response.statusCode).toBe(200)
+
+    const body = JSON.parse(response.body) as Record<string, unknown>
+    expect(body.sessionId).toBe('test-uuid')
+    expect(body.status).toBe('completed')
+    expect(body.filterType).toBe('simple')
+    expect(body.caption).toBe('楽しい思い出！')
+    expect(body.collageImageUrl).toBe('https://presigned/download-url')
+    expect(body.createdAt).toBe('2026-03-16T14:30:00Z')
+  })
+
+  it('should return session without collageImageUrl when not yet processed', async () => {
     const session = {
       sessionId: 'test-uuid',
       createdAt: '2026-03-16T14:30:00Z',
@@ -60,7 +93,49 @@ describe('session-get handler', () => {
     const body = JSON.parse(response.body) as Record<string, unknown>
     expect(body.sessionId).toBe('test-uuid')
     expect(body.status).toBe('uploading')
-    expect(body.filterType).toBe('simple')
+    expect(body.collageImageUrl).toBeUndefined()
+    expect(mockGeneratePresignedDownloadUrl).not.toHaveBeenCalled()
+  })
+
+  it('should generate presigned URL with 1 hour expiry', async () => {
+    const session = {
+      sessionId: 'test-uuid',
+      createdAt: '2026-03-16T14:30:00Z',
+      filterType: 'simple',
+      filter: 'beauty',
+      status: 'completed',
+      photoCount: 4,
+      downloadKey: 'downloads/test-uuid.png',
+      ttl: 0,
+    }
+    mockGetSession.mockResolvedValueOnce(session)
+
+    await invoke(createEvent('test-uuid'))
+
+    expect(mockGeneratePresignedDownloadUrl).toHaveBeenCalledWith(
+      'downloads/test-uuid.png',
+      3600,
+    )
+  })
+
+  it('should not expose internal fields like ttl or photoCount', async () => {
+    const session = {
+      sessionId: 'test-uuid',
+      createdAt: '2026-03-16T14:30:00Z',
+      filterType: 'simple',
+      filter: 'beauty',
+      status: 'uploading',
+      photoCount: 4,
+      ttl: 999999,
+    }
+    mockGetSession.mockResolvedValueOnce(session)
+
+    const response = await invoke(createEvent('test-uuid'))
+    const body = JSON.parse(response.body) as Record<string, unknown>
+
+    expect(body).not.toHaveProperty('ttl')
+    expect(body).not.toHaveProperty('photoCount')
+    expect(body).not.toHaveProperty('downloadKey')
   })
 
   it('should return 404 when session not found', async () => {

--- a/src/functions/session-get/handler.ts
+++ b/src/functions/session-get/handler.ts
@@ -1,5 +1,6 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda'
 import { getSession } from '../../lib/dynamodb'
+import { generatePresignedDownloadUrl } from '../../lib/s3'
 import { success, error } from '../../utils/response'
 
 export const handler: APIGatewayProxyHandler = async (event) => {
@@ -14,7 +15,20 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return error('Session not found', 404)
     }
 
-    return success(session)
+    // Generate presigned URL for collage download if available
+    const collageImageUrl = session.downloadKey
+      ? await generatePresignedDownloadUrl(session.downloadKey, 3600)
+      : undefined
+
+    return success({
+      sessionId: session.sessionId,
+      status: session.status,
+      filterType: session.filterType,
+      filter: session.filter,
+      caption: session.caption,
+      collageImageUrl,
+      createdAt: session.createdAt,
+    })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Internal server error'
     return error(message, 500)


### PR DESCRIPTION
## Summary
- API 仕様書 (docs/api.md) に準拠したレスポンス形式に変更
- `downloadKey` から S3 Presigned GET URL (1時間有効) を生成して `collageImageUrl` として返す
- 内部フィールド (ttl, photoCount, downloadKey, printImageKey 等) をレスポンスから除外
- CDK: session-get Lambda に `S3_BUCKET` 環境変数 + S3 読み取り権限を追加

### レスポンス形式 (仕様書準拠)
```json
{
  "sessionId": "uuid-xxxx",
  "status": "completed",
  "filterType": "simple",
  "filter": "beauty",
  "caption": "AIが生成したキャプション",
  "collageImageUrl": "https://presigned-url...",
  "createdAt": "2026-03-16T14:30:00Z"
}
```

## Test plan
- [x] `npm run test` — 145 tests passed (session-get: 4→7テストに増加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors
- [x] `cd cdk && npx cdk synth` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)