### PR TITLE
feat: AI フィルター実装 (Stability AI on Bedrock)

### DIFF
--- a/src/functions/filter-apply/handler.test.ts
+++ b/src/functions/filter-apply/handler.test.ts
@@ -19,12 +19,25 @@ const { mockSharp, mockSharpInstance } = vi.hoisted(() => {
   return { mockSharpInstance: instance, mockSharp: vi.fn(() => instance) }
 })
 
+const { mockBedrockSend } = vi.hoisted(() => ({
+  mockBedrockSend: vi.fn(),
+}))
+
 vi.mock('../../lib/s3', () => ({
   getObject: (...args: unknown[]) => mockGetObject(...args) as unknown,
   putObject: (...args: unknown[]) => mockPutObject(...args) as unknown,
 }))
 
 vi.mock('sharp', () => ({ default: mockSharp }))
+
+vi.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: class {
+    send = mockBedrockSend
+  },
+  InvokeModelCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
 
 import { handler } from './handler'
 import type { PipelineInput } from '../../lib/types'
@@ -98,5 +111,78 @@ describe('filter-apply handler', () => {
 
     expect(result.sessionId).toBe('test-uuid')
     expect(result.bucket).toBe('test-bucket')
+  })
+})
+
+describe('filter-apply handler (AI filters)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetObject.mockResolvedValue(Buffer.from([255, 0, 0]))
+    mockPutObject.mockResolvedValue(undefined)
+
+    // Mock Bedrock response with base64-encoded PNG
+    const fakeBase64 = Buffer.from([1, 2, 3]).toString('base64')
+    mockBedrockSend.mockResolvedValue({
+      body: new TextEncoder().encode(
+        JSON.stringify({ images: [fakeBase64] }),
+      ),
+    })
+  })
+
+  it('should call Bedrock for anime filter', async () => {
+    const result = await handler({
+      ...baseInput,
+      filterType: 'ai',
+      filter: 'anime',
+    })
+
+    expect(mockBedrockSend).toHaveBeenCalledTimes(2)
+    expect(mockSharpInstance.blur).not.toHaveBeenCalled()
+    expect(result.filteredImages).toHaveLength(2)
+  })
+
+  it('should call Bedrock for popart filter', async () => {
+    await handler({
+      ...baseInput,
+      filterType: 'ai',
+      filter: 'popart',
+    })
+
+    expect(mockBedrockSend).toHaveBeenCalledTimes(2)
+  })
+
+  it('should call Bedrock for watercolor filter', async () => {
+    await handler({
+      ...baseInput,
+      filterType: 'ai',
+      filter: 'watercolor',
+    })
+
+    expect(mockBedrockSend).toHaveBeenCalledTimes(2)
+  })
+
+  it('should save AI-filtered images to S3', async () => {
+    await handler({
+      ...baseInput,
+      filterType: 'ai',
+      filter: 'anime',
+    })
+
+    expect(mockPutObject).toHaveBeenCalledTimes(2)
+    expect(mockPutObject).toHaveBeenCalledWith(
+      'filtered/test-uuid/1.png',
+      expect.any(Buffer) as Buffer,
+    )
+  })
+
+  it('should fall back to simple filter for simple filterType even with AI filter name', async () => {
+    await handler({
+      ...baseInput,
+      filterType: 'simple',
+      filter: 'anime',
+    })
+
+    expect(mockBedrockSend).not.toHaveBeenCalled()
+    expect(mockSharpInstance.png).toHaveBeenCalled()
   })
 })

--- a/src/functions/filter-apply/handler.ts
+++ b/src/functions/filter-apply/handler.ts
@@ -1,12 +1,15 @@
 import sharp from 'sharp'
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
 import { getObject, putObject } from '../../lib/s3'
-import type { PipelineInput, Filter } from '../../lib/types'
+import type { PipelineInput, Filter, AiFilter } from '../../lib/types'
 
 interface FilterApplyOutput extends PipelineInput {
   readonly filteredImages: readonly string[]
 }
 
-const applyFilter = (pipeline: sharp.Sharp, filter: Filter): sharp.Sharp => {
+const bedrock = new BedrockRuntimeClient({})
+
+const applySimpleFilter = (pipeline: sharp.Sharp, filter: Filter): sharp.Sharp => {
   switch (filter) {
     case 'natural':
       return pipeline
@@ -18,21 +21,75 @@ const applyFilter = (pipeline: sharp.Sharp, filter: Filter): sharp.Sharp => {
       return pipeline.greyscale()
     case 'sepia':
       return pipeline.greyscale().tint({ r: 112, g: 66, b: 20 })
-    case 'anime':
-    case 'popart':
-    case 'watercolor':
+    default:
       return pipeline
   }
 }
 
+/** Map AI filter names to Stability AI style_preset values. */
+const AI_STYLE_PRESETS: Record<AiFilter, string> = {
+  anime: 'anime',
+  popart: 'comic-book',
+  watercolor: 'digital-art',
+}
+
+/** Map AI filter names to descriptive prompts. */
+const AI_PROMPTS: Record<AiFilter, string> = {
+  anime: 'anime style illustration, vibrant colors, cel shading',
+  popart: 'pop art style, bold colors, halftone dots, comic book aesthetic',
+  watercolor: 'watercolor painting, soft brushstrokes, artistic, flowing colors',
+}
+
+interface StabilityResponse {
+  readonly images: readonly string[]
+}
+
+/** Apply AI style transfer via Stability AI on Bedrock. */
+const applyAiFilter = async (imageBuffer: Buffer, filter: AiFilter): Promise<Buffer> => {
+  const base64Image = imageBuffer.toString('base64')
+
+  const response = await bedrock.send(
+    new InvokeModelCommand({
+      modelId: 'us.stability.stable-image-style-guide-v1:0',
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({
+        image: base64Image,
+        prompt: AI_PROMPTS[filter],
+        style_preset: AI_STYLE_PRESETS[filter],
+        output_format: 'png',
+        fidelity: 0.7,
+      }),
+    }),
+  )
+
+  const body = JSON.parse(
+    new TextDecoder().decode(response.body),
+  ) as StabilityResponse
+
+  const outputBase64 = body.images[0]
+  if (!outputBase64) throw new Error('Stability AI returned no images')
+
+  return Buffer.from(outputBase64, 'base64')
+}
+
+const isAiFilter = (filter: Filter): filter is AiFilter =>
+  filter === 'anime' || filter === 'popart' || filter === 'watercolor'
+
 export const handler = async (event: PipelineInput): Promise<FilterApplyOutput> => {
-  const { sessionId, filter, images } = event
+  const { sessionId, filter, filterType, images } = event
 
   const filteredImages = await Promise.all(
     images.map(async (imageKey, i) => {
       const imageBuffer = await getObject(imageKey)
-      const pipeline = applyFilter(sharp(imageBuffer), filter)
-      const outputBuffer = await pipeline.png().toBuffer()
+
+      let outputBuffer: Buffer
+      if (filterType === 'ai' && isAiFilter(filter)) {
+        outputBuffer = await applyAiFilter(imageBuffer, filter)
+      } else {
+        const pipeline = applySimpleFilter(sharp(imageBuffer), filter)
+        outputBuffer = await pipeline.png().toBuffer()
+      }
 
       const outputKey = `filtered/${sessionId}/${String(i + 1)}.png`
       await putObject(outputKey, outputBuffer)


### PR DESCRIPTION
## Summary
- `filterType=ai` の場合に Bedrock Stability AI Style Guide API でスタイル変換を実行
- 3スタイル対応:
  - `anime` → style_preset: `anime`
  - `popart` → style_preset: `comic-book`
  - `watercolor` → style_preset: `digital-art`
- 4枚並列で Bedrock API 呼び出し (Promise.all)
- `filterType=simple` の場合は従来通り sharp でローカル処理 (変更なし)

### 使用モデル
- `us.stability.stable-image-style-guide-v1:0`
- fidelity: 0.7 (元画像の構図を7割維持)

### CDK 既存設定
- filter-apply Lambda には既に `bedrock:InvokeModel` 権限が付与済み (app-stack.ts L115-118)

## Test plan
- [x] `npm run test` — 147 tests passed (AI フィルター5テスト追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)