### PR TITLE
fix: pipeline-complete の collageImageUrl を Presigned URL に変換

### DIFF
--- a/src/functions/pipeline-complete/handler.test.ts
+++ b/src/functions/pipeline-complete/handler.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-const { mockIotSend, mockUpdateSession, mockSendToSession } = vi.hoisted(() => ({
+const { mockIotSend, mockUpdateSession, mockSendToSession, mockGeneratePresignedDownloadUrl } = vi.hoisted(() => ({
   mockIotSend: vi.fn(),
   mockUpdateSession: vi.fn(),
   mockSendToSession: vi.fn(),
+  mockGeneratePresignedDownloadUrl: vi.fn(),
 }))
 
 vi.mock('@aws-sdk/client-iot-data-plane', () => ({
@@ -17,6 +18,11 @@ vi.mock('@aws-sdk/client-iot-data-plane', () => ({
 
 vi.mock('../../lib/dynamodb', () => ({
   updateSession: (...args: unknown[]) => mockUpdateSession(...args) as unknown,
+}))
+
+vi.mock('../../lib/s3', () => ({
+  generatePresignedDownloadUrl: (...args: unknown[]) =>
+    mockGeneratePresignedDownloadUrl(...args) as unknown,
 }))
 
 vi.mock('../../lib/websocket', () => ({
@@ -45,6 +51,7 @@ describe('pipeline-complete handler', () => {
     mockIotSend.mockResolvedValue(undefined)
     mockUpdateSession.mockResolvedValue(undefined)
     mockSendToSession.mockResolvedValue(undefined)
+    mockGeneratePresignedDownloadUrl.mockResolvedValue('https://presigned/collage-url')
   })
 
   it('should publish print job to IoT Core', async () => {
@@ -68,13 +75,21 @@ describe('pipeline-complete handler', () => {
     )
   })
 
-  it('should send completed event via WebSocket', async () => {
+  it('should send completed event with presigned URL via WebSocket', async () => {
     await handler(baseInput)
 
+    expect(mockGeneratePresignedDownloadUrl).toHaveBeenCalledWith(
+      'downloads/test-uuid.png',
+      3600,
+    )
     expect(mockSendToSession).toHaveBeenCalledWith(
       'test-uuid',
       expect.objectContaining({
         type: 'completed',
+        data: expect.objectContaining({
+          sessionId: 'test-uuid',
+          collageImageUrl: 'https://presigned/collage-url',
+        }) as Record<string, unknown>,
       }),
     )
   })

--- a/src/functions/pipeline-complete/handler.ts
+++ b/src/functions/pipeline-complete/handler.ts
@@ -1,5 +1,6 @@
 import { IoTDataPlaneClient, PublishCommand } from '@aws-sdk/client-iot-data-plane'
 import { updateSession } from '../../lib/dynamodb'
+import { generatePresignedDownloadUrl } from '../../lib/s3'
 import { sendToSession } from '../../lib/websocket'
 import type { PipelineInput } from '../../lib/types'
 
@@ -49,12 +50,13 @@ export const handler = async (
     downloadKey,
   })
 
-  // Notify via WebSocket
+  // Notify via WebSocket with presigned URL
+  const collageImageUrl = await generatePresignedDownloadUrl(downloadKey, 3600)
   await sendToSession(sessionId, {
     type: 'completed',
     data: {
       sessionId,
-      collageImageUrl: collageKey,
+      collageImageUrl,
     },
   })
 


### PR DESCRIPTION
## Summary
- WebSocket `completed` イベントで S3 キー (`collages/uuid.png`) がそのまま送信されていた問題を修正
- `downloadKey` から S3 Presigned GET URL (1時間有効) を生成して `collageImageUrl` として返却

Fixes #34

## Test plan
- [x] `npm run test` — 160 tests passed
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)