### PR TITLE
fix: filterType と filter のクロスフィールドバリデーション追加

### DIFF
--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -69,6 +69,36 @@ describe('CreateSessionSchema', () => {
     })
     expect(result.success).toBe(false)
   })
+
+  it('should reject AI filter with simple filterType', () => {
+    const result = CreateSessionSchema.safeParse({
+      filterType: 'simple',
+      filter: 'anime',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject simple filter with AI filterType', () => {
+    const result = CreateSessionSchema.safeParse({
+      filterType: 'ai',
+      filter: 'beauty',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should accept all simple filters with simple filterType', () => {
+    for (const filter of ['natural', 'beauty', 'bright', 'mono', 'sepia']) {
+      const result = CreateSessionSchema.safeParse({ filterType: 'simple', filter })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('should accept all AI filters with AI filterType', () => {
+    for (const filter of ['anime', 'popart', 'watercolor']) {
+      const result = CreateSessionSchema.safeParse({ filterType: 'ai', filter })
+      expect(result.success).toBe(true)
+    }
+  })
 })
 
 describe('ProcessSchema', () => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,18 +1,22 @@
 import { z } from 'zod'
 
+const SIMPLE_FILTERS = ['natural', 'beauty', 'bright', 'mono', 'sepia'] as const
+const AI_FILTERS = ['anime', 'popart', 'watercolor'] as const
+
 export const CreateSessionSchema = z.object({
   filterType: z.enum(['simple', 'ai']),
-  filter: z.enum([
-    'natural',
-    'beauty',
-    'bright',
-    'mono',
-    'sepia',
-    'anime',
-    'popart',
-    'watercolor',
-  ]),
+  filter: z.enum([...SIMPLE_FILTERS, ...AI_FILTERS]),
   photoCount: z.number().int().min(1).max(4).default(4),
+}).superRefine((data, ctx) => {
+  const isSimple = data.filterType === 'simple'
+  const validFilters = isSimple ? SIMPLE_FILTERS : AI_FILTERS
+  if (!(validFilters as readonly string[]).includes(data.filter)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `filter '${data.filter}' is not valid for filterType '${data.filterType}'`,
+      path: ['filter'],
+    })
+  }
 })
 
 export type CreateSessionInput = z.infer<typeof CreateSessionSchema>


### PR DESCRIPTION
## Summary
- `filterType: 'simple'` + `filter: 'anime'` のような不正な組み合わせを拒否するバリデーション追加
- zod の `.superRefine()` でクロスフィールドチェック

Fixes #36

## Test plan
- [x] `npm run test` — 164 tests passed (バリデーション4テスト追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)