### PR TITLE
fix: yaji-comment-fast の Array.sort() ミューテーション修正

### DIFF
--- a/src/functions/yaji-comment-fast/handler.ts
+++ b/src/functions/yaji-comment-fast/handler.ts
@@ -36,7 +36,7 @@ export const handler = async (event: YajiInput): Promise<YajiInput> => {
   const faces = response.FaceDetails ?? []
   if (faces.length === 0) return event
 
-  const topEmotion = faces[0]?.Emotions?.sort(
+  const topEmotion = [...(faces[0]?.Emotions ?? [])].sort(
     (a, b) => (b.Confidence ?? 0) - (a.Confidence ?? 0),
   )[0]
 


### PR DESCRIPTION
## Summary
- `Emotions` 配列を `.sort()` で直接ミューテートしていた問題を修正
- スプレッドでコピーしてからソートするよう変更

Fixes #40

## Test plan
- [x] `npm run test` — 164 tests passed
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)