### PR TITLE
fix: stats-update に status ホワイトリストバリデーション追加

### DIFF
--- a/src/functions/stats-update/handler.test.ts
+++ b/src/functions/stats-update/handler.test.ts
@@ -88,4 +88,43 @@ describe('stats-update handler', () => {
 
     expect(mockDocClientSend).not.toHaveBeenCalled()
   })
+
+  it('should skip records with invalid status values', async () => {
+    const event: DynamoDBStreamEvent = {
+      Records: [
+        {
+          eventName: 'INSERT',
+          dynamodb: {
+            NewImage: {
+              sessionId: { S: 'test-uuid' },
+              status: { S: 'hacked_column' },
+            },
+          },
+        },
+      ],
+    }
+
+    await handler(event, mockContext, noop)
+
+    expect(mockDocClientSend).not.toHaveBeenCalled()
+  })
+
+  it('should skip records with missing status', async () => {
+    const event: DynamoDBStreamEvent = {
+      Records: [
+        {
+          eventName: 'INSERT',
+          dynamodb: {
+            NewImage: {
+              sessionId: { S: 'test-uuid' },
+            },
+          },
+        },
+      ],
+    }
+
+    await handler(event, mockContext, noop)
+
+    expect(mockDocClientSend).not.toHaveBeenCalled()
+  })
 })

--- a/src/functions/stats-update/handler.ts
+++ b/src/functions/stats-update/handler.ts
@@ -8,10 +8,15 @@ export const handler: DynamoDBStreamHandler = async (event) => {
   const tableName = process.env.STATS_TABLE ?? process.env.DYNAMODB_TABLE
   if (!tableName) return
 
+  const VALID_STATUSES = new Set(['uploading', 'processing', 'completed', 'printed', 'failed'])
+
   for (const record of event.Records) {
     if (record.eventName === 'REMOVE') continue
 
-    const status = record.dynamodb?.NewImage?.status?.S ?? 'unknown'
+    const rawStatus = record.dynamodb?.NewImage?.status?.S
+    if (!rawStatus || !VALID_STATUSES.has(rawStatus)) continue
+
+    const status = rawStatus
     const today = new Date().toISOString().slice(0, 10)
 
     await docClient.send(


### PR DESCRIPTION
## Summary
- DynamoDB Stream の `status` 値を未検証で `ExpressionAttributeNames` に使用していた論理バグを修正
- 有効な status (`uploading/processing/completed/printed/failed`) のホワイトリストで検証
- 無効な値・未設定の場合はレコードをスキップ

Fixes #41

## Test plan
- [x] `npm run test` — 166 tests passed (無効status/status未設定のテスト2件追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)