### PR TITLE
fix: エラーレスポンスから内部情報の漏洩を防止

### DIFF
--- a/src/functions/process-start/handler.ts
+++ b/src/functions/process-start/handler.ts
@@ -10,12 +10,14 @@ export const handler: APIGatewayProxyHandler = async (event) => {
   try {
     const stateMachineArn = process.env.STATE_MACHINE_ARN
     if (!stateMachineArn) {
-      return error('STATE_MACHINE_ARN is not set', 500)
+      console.error('Missing required configuration: STATE_MACHINE_ARN')
+      return error('Service configuration error', 500)
     }
 
     const bucket = process.env.S3_BUCKET
     if (!bucket) {
-      return error('S3_BUCKET is not set', 500)
+      console.error('Missing required configuration: S3_BUCKET')
+      return error('Service configuration error', 500)
     }
 
     const sessionId = event.pathParameters?.sessionId
@@ -57,7 +59,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     return success({ sessionId, status: 'processing' }, 202)
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Internal server error'
-    return error(message, 500)
+    console.error('process-start failed:', err)
+    return error('Internal server error', 500)
   }
 }

--- a/src/functions/session-create/handler.ts
+++ b/src/functions/session-create/handler.ts
@@ -12,7 +12,8 @@ export const handler: APIGatewayProxyHandler = async (event) => {
   try {
     const websocketUrl = process.env.WEBSOCKET_URL
     if (!websocketUrl) {
-      return error('WEBSOCKET_URL is not set', 500)
+      console.error('Missing required configuration: WEBSOCKET_URL')
+      return error('Service configuration error', 500)
     }
 
     const parsed = CreateSessionSchema.safeParse(
@@ -49,7 +50,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     return success({ sessionId, uploadUrls, websocketUrl }, 201)
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Internal server error'
-    return error(message, 500)
+    console.error('session-create failed:', err)
+    return error('Internal server error', 500)
   }
 }

--- a/src/functions/session-get/handler.ts
+++ b/src/functions/session-get/handler.ts
@@ -30,7 +30,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       createdAt: session.createdAt,
     })
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Internal server error'
-    return error(message, 500)
+    console.error('session-get failed:', err)
+    return error('Internal server error', 500)
   }
 }


### PR DESCRIPTION
## Summary
- 環境変数名 (`STATE_MACHINE_ARN is not set` 等) がクライアントに返されていた問題を修正
- AWS SDK エラーメッセージがそのまま 500 レスポンスに含まれていた問題を修正
- 詳細は `console.error` で CloudWatch Logs に出力、クライアントには汎用メッセージのみ返却

### 対象
- `session-create`: WEBSOCKET_URL チェック + catch
- `session-get`: catch
- `process-start`: STATE_MACHINE_ARN / S3_BUCKET チェック + catch

Fixes #42

## Test plan
- [x] `npm run test` — 166 tests passed
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)