### PR TITLE
fix: CORS Access-Control-Allow-Origin を環境変数で制御可能に

### DIFF
--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
 import { success, error } from './response'
 
 describe('response', () => {
+  const originalAllowedOrigin = process.env.ALLOWED_ORIGIN
+
+  afterEach(() => {
+    if (originalAllowedOrigin === undefined) {
+      delete process.env.ALLOWED_ORIGIN
+    } else {
+      process.env.ALLOWED_ORIGIN = originalAllowedOrigin
+    }
+  })
+
   describe('success', () => {
+    beforeEach(() => {
+      delete process.env.ALLOWED_ORIGIN
+    })
+
     it('should return 200 with JSON body by default', () => {
       const result = success({ message: 'ok' })
       expect(result.statusCode).toBe(200)
@@ -35,6 +49,22 @@ describe('response', () => {
 
     it('should include CORS headers', () => {
       const result = error('Bad request', 400)
+      expect(result.headers?.['Access-Control-Allow-Origin']).toBe('*')
+    })
+  })
+
+  describe('ALLOWED_ORIGIN', () => {
+    it('should use ALLOWED_ORIGIN env var when set', () => {
+      process.env.ALLOWED_ORIGIN = 'https://receipt-purikura.example.com'
+
+      const result = success({ ok: true })
+      expect(result.headers?.['Access-Control-Allow-Origin']).toBe('https://receipt-purikura.example.com')
+    })
+
+    it('should fallback to * when ALLOWED_ORIGIN is not set', () => {
+      delete process.env.ALLOWED_ORIGIN
+
+      const result = success({ ok: true })
       expect(result.headers?.['Access-Control-Allow-Origin']).toBe('*')
     })
   })

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,22 +1,22 @@
 import type { APIGatewayProxyResult } from 'aws-lambda'
 
-const CORS_HEADERS = {
+const getCorsHeaders = (): Record<string, string> => ({
   'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': process.env.ALLOWED_ORIGIN ?? '*',
   'Access-Control-Allow-Headers': 'Content-Type',
   'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-} as const
+})
 
 /** Build a successful API Gateway response. */
 export const success = (data: unknown, statusCode = 200): APIGatewayProxyResult => ({
   statusCode,
-  headers: CORS_HEADERS,
+  headers: getCorsHeaders(),
   body: JSON.stringify(data),
 })
 
 /** Build an error API Gateway response. */
 export const error = (message: string, statusCode = 500): APIGatewayProxyResult => ({
   statusCode,
-  headers: CORS_HEADERS,
+  headers: getCorsHeaders(),
   body: JSON.stringify({ error: message }),
 })


### PR DESCRIPTION
## Summary
- `Access-Control-Allow-Origin: '*'` のハードコードを `ALLOWED_ORIGIN` 環境変数で上書き可能に変更
- 未設定時は `'*'` にフォールバック (dev 環境の後方互換)
- 本番環境では CDK で `ALLOWED_ORIGIN` を設定してオリジンを制限

Fixes #43

## Test plan
- [x] `npm run test` — 168 tests passed (ALLOWED_ORIGIN テスト2件追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)