### PR TITLE
fix: Bedrock/Comprehend API 呼び出しの例外ハンドリング追加

### DIFF
--- a/src/functions/caption-generate/handler.test.ts
+++ b/src/functions/caption-generate/handler.test.ts
@@ -111,4 +111,25 @@ describe('caption-generate handler', () => {
     expect(result.sessionId).toBe('test-uuid')
     expect(result.collageKey).toBe('collages/test-uuid.png')
   })
+
+  it('should return empty caption when Bedrock fails', async () => {
+    mockBedrockSend.mockRejectedValue(new Error('Bedrock throttling'))
+
+    const result = await handler(baseInput)
+
+    expect(result.caption).toBe('')
+    expect(result.sentiment).toBe('NEUTRAL')
+    expect(result.sentimentScore).toBe(0)
+    expect(mockUpdateSession).toHaveBeenCalled()
+  })
+
+  it('should return default sentiment when Comprehend fails', async () => {
+    mockComprehendSend.mockRejectedValue(new Error('Comprehend error'))
+
+    const result = await handler(baseInput)
+
+    expect(result.caption).toBe('楽しい思い出の一枚！')
+    expect(result.sentiment).toBe('NEUTRAL')
+    expect(result.sentimentScore).toBe(0)
+  })
 })

--- a/src/functions/caption-generate/handler.ts
+++ b/src/functions/caption-generate/handler.ts
@@ -30,53 +30,64 @@ export const handler = async (event: CaptionInput): Promise<CaptionOutput> => {
   const base64Image = imageBuffer.toString('base64')
 
   // Generate caption with Bedrock Claude
-  const bedrockResponse = await bedrock.send(
-    new InvokeModelCommand({
-      modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
-      contentType: 'application/json',
-      accept: 'application/json',
-      body: JSON.stringify({
-        anthropic_version: 'bedrock-2023-05-31',
-        max_tokens: 100,
-        messages: [
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'image',
-                source: {
-                  type: 'base64',
-                  media_type: 'image/png',
-                  data: base64Image,
+  let caption = ''
+  try {
+    const bedrockResponse = await bedrock.send(
+      new InvokeModelCommand({
+        modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: JSON.stringify({
+          anthropic_version: 'bedrock-2023-05-31',
+          max_tokens: 100,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: base64Image,
+                  },
                 },
-              },
-              {
-                type: 'text',
-                text: 'この写真に短い日本語キャプションをつけてください。楽しく、ポップな雰囲気で1文でお願いします。',
-              },
-            ],
-          },
-        ],
+                {
+                  type: 'text',
+                  text: 'この写真に短い日本語キャプションをつけてください。楽しく、ポップな雰囲気で1文でお願いします。',
+                },
+              ],
+            },
+          ],
+        }),
       }),
-    }),
-  )
+    )
 
-  const bedrockBody = JSON.parse(
-    new TextDecoder().decode(bedrockResponse.body),
-  ) as BedrockResponse
-  const caption = bedrockBody.content[0]?.text ?? ''
+    const bedrockBody = JSON.parse(
+      new TextDecoder().decode(bedrockResponse.body),
+    ) as BedrockResponse
+    caption = bedrockBody.content[0]?.text ?? ''
+  } catch (err) {
+    console.error('Bedrock caption generation failed:', err)
+  }
 
-  // Sentiment analysis with Comprehend
-  const sentimentResponse = await comprehend.send(
-    new DetectSentimentCommand({
-      Text: caption,
-      LanguageCode: 'ja',
-    }),
-  )
-
-  const sentiment = sentimentResponse.Sentiment ?? 'NEUTRAL'
-  const scores = sentimentResponse.SentimentScore
-  const sentimentScore = scores?.Positive ?? 0
+  // Sentiment analysis with Comprehend (skip if no caption)
+  let sentiment = 'NEUTRAL'
+  let sentimentScore = 0
+  if (caption) {
+    try {
+      const sentimentResponse = await comprehend.send(
+        new DetectSentimentCommand({
+          Text: caption,
+          LanguageCode: 'ja',
+        }),
+      )
+      sentiment = sentimentResponse.Sentiment ?? 'NEUTRAL'
+      sentimentScore = sentimentResponse.SentimentScore?.Positive ?? 0
+    } catch (err) {
+      console.error('Comprehend sentiment analysis failed:', err)
+    }
+  }
 
   // Update session
   await updateSession(sessionId, createdAt, {

--- a/src/functions/yaji-comment-deep/handler.test.ts
+++ b/src/functions/yaji-comment-deep/handler.test.ts
@@ -73,4 +73,13 @@ describe('yaji-comment-deep handler', () => {
 
     expect(result.bucket).toBe('test-bucket')
   })
+
+  it('should return event without error when Bedrock fails', async () => {
+    mockBedrockSend.mockRejectedValue(new Error('Bedrock throttling'))
+
+    const result = await handler(baseInput)
+
+    expect(result.sessionId).toBe('test-uuid')
+    expect(mockSendToSession).not.toHaveBeenCalled()
+  })
 })

--- a/src/functions/yaji-comment-deep/handler.ts
+++ b/src/functions/yaji-comment-deep/handler.ts
@@ -20,55 +20,59 @@ export const handler = async (event: YajiInput): Promise<YajiInput> => {
   const firstImage = images[0]
   if (!firstImage) return event
 
-  const imageBuffer = await getObject(firstImage)
-  const base64Image = imageBuffer.toString('base64')
+  try {
+    const imageBuffer = await getObject(firstImage)
+    const base64Image = imageBuffer.toString('base64')
 
-  const response = await bedrock.send(
-    new InvokeModelCommand({
-      modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
-      contentType: 'application/json',
-      accept: 'application/json',
-      body: JSON.stringify({
-        anthropic_version: 'bedrock-2023-05-31',
-        max_tokens: 50,
-        messages: [
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'image',
-                source: {
-                  type: 'base64',
-                  media_type: 'image/jpeg',
-                  data: base64Image,
+    const response = await bedrock.send(
+      new InvokeModelCommand({
+        modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: JSON.stringify({
+          anthropic_version: 'bedrock-2023-05-31',
+          max_tokens: 50,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'image',
+                  source: {
+                    type: 'base64',
+                    media_type: 'image/jpeg',
+                    data: base64Image,
+                  },
                 },
-              },
-              {
-                type: 'text',
-                text: 'この写真の人にニコニコ動画風のやじコメントを1つだけ書いてください。短く面白く、ネットスラング可。',
-              },
-            ],
-          },
-        ],
+                {
+                  type: 'text',
+                  text: 'この写真の人にニコニコ動画風のやじコメントを1つだけ書いてください。短く面白く、ネットスラング可。',
+                },
+              ],
+            },
+          ],
+        }),
       }),
-    }),
-  )
+    )
 
-  const body = JSON.parse(
-    new TextDecoder().decode(response.body),
-  ) as BedrockResponse
-  const text = body.content[0]?.text ?? ''
+    const body = JSON.parse(
+      new TextDecoder().decode(response.body),
+    ) as BedrockResponse
+    const text = body.content[0]?.text ?? ''
 
-  if (text) {
-    await sendToSession(sessionId, {
-      type: 'yajiComment',
-      data: {
-        text,
-        emotion: 'deep',
-        lane: 'deep',
-        timestamp: Math.floor(Date.now() / 1000),
-      },
-    })
+    if (text) {
+      await sendToSession(sessionId, {
+        type: 'yajiComment',
+        data: {
+          text,
+          emotion: 'deep',
+          lane: 'deep',
+          timestamp: Math.floor(Date.now() / 1000),
+        },
+      })
+    }
+  } catch (err) {
+    console.error('yaji-comment-deep Bedrock invocation failed:', err)
   }
 
   return event


### PR DESCRIPTION
## Summary
- **caption-generate**: Bedrock 失敗時は空キャプション、Comprehend 失敗時はデフォルト感情値でフォールバック
- **yaji-comment-deep**: Bedrock 失敗時はコメント送信をスキップして正常終了
- いずれも `console.error` で CloudWatch Logs に詳細出力

Fixes #44

## Test plan
- [x] `npm run test` — 171 tests passed (失敗ケース3テスト追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)