### PR TITLE
fix: S3 エラーメッセージから内部キーパスを除去

### DIFF
--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -43,7 +43,10 @@ export const getObject = async (key: string): Promise<Buffer> => {
   })
   const response = await client.send(command)
   const bytes = await response.Body?.transformToByteArray()
-  if (!bytes) throw new Error(`Empty body for key: ${key}`)
+  if (!bytes) {
+    console.error('Empty body returned from S3 for key:', key)
+    throw new Error('Empty body returned from S3')
+  }
   return Buffer.from(bytes)
 }
 


### PR DESCRIPTION
## Summary
- `getObject` のエラーメッセージに S3 キー (`originals/`, `filtered/` 等) が含まれていた問題を修正
- 詳細は `console.error` で CloudWatch Logs に出力、throw メッセージは汎用化

Fixes #48

## Test plan
- [x] `npm run test` — 171 tests passed
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)