### PR TITLE
fix: session-create の JSON.parse 失敗時に内部詳細を隠蔽

### DIFF
--- a/src/functions/session-create/handler.test.ts
+++ b/src/functions/session-create/handler.test.ts
@@ -141,6 +141,16 @@ describe('session-create handler', () => {
     expect(response.statusCode).toBe(400)
   })
 
+  it('should return 400 for malformed JSON body', async () => {
+    const event = { ...createEvent({}), body: '{invalid json' } as APIGatewayProxyEvent
+
+    const response = await invoke(event)
+    expect(response.statusCode).toBe(400)
+
+    const body = JSON.parse(response.body) as { error: string }
+    expect(body.error).toBe('Invalid JSON in request body')
+  })
+
   it('should return 500 when DynamoDB fails', async () => {
     mockPutSession.mockRejectedValueOnce(new Error('DynamoDB error'))
     mockGeneratePresignedUploadUrl.mockResolvedValue('https://presigned/url')

--- a/src/functions/session-create/handler.ts
+++ b/src/functions/session-create/handler.ts
@@ -16,9 +16,14 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return error('Service configuration error', 500)
     }
 
-    const parsed = CreateSessionSchema.safeParse(
-      JSON.parse(event.body ?? '{}'),
-    )
+    let body: unknown
+    try {
+      body = JSON.parse(event.body ?? '{}')
+    } catch {
+      return error('Invalid JSON in request body', 400)
+    }
+
+    const parsed = CreateSessionSchema.safeParse(body)
     if (!parsed.success) {
       return error(parsed.error.message, 400)
     }


### PR DESCRIPTION
## Summary
- 不正 JSON ボディで `SyntaxError` メッセージがクライアントに漏洩していた問題を修正
- `JSON.parse` を個別 try-catch で囲み、`400 'Invalid JSON in request body'` を返却

Fixes #50

## Test plan
- [x] `npm run test` — 172 tests passed (不正JSONテスト1件追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)