### PR TITLE
feat: face-detection, caption-generate に WebSocket 進捗通知追加

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -103,11 +103,16 @@ export class AppStack extends cdk.Stack {
       resources: [webSocketApiArn],
     }))
 
-    // face-detection: S3 GetObject, Rekognition
+    // face-detection: S3 GetObject, Rekognition, WebSocket (progress notifications)
     storage.bucket.grantRead(api.faceDetectionFn)
+    storage.connectionsTable.grantReadData(api.faceDetectionFn)
     api.faceDetectionFn.addToRolePolicy(new iam.PolicyStatement({
       actions: ['rekognition:DetectFaces'],
       resources: ['*'],
+    }))
+    api.faceDetectionFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['execute-api:ManageConnections'],
+      resources: [webSocketApiArn],
     }))
 
     // filter-apply: S3 read/write, Bedrock, WebSocket (progress notifications)

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -229,6 +229,8 @@ export class Api extends Construct {
       environment: {
         S3_BUCKET: bucketName,
         DYNAMODB_TABLE: sessionsTableName,
+        CONNECTIONS_TABLE: connectionsTableName,
+        WEBSOCKET_URL: websocketUrl,
       },
     }))
 

--- a/src/functions/caption-generate/handler.test.ts
+++ b/src/functions/caption-generate/handler.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-const { mockBedrockSend, mockComprehendSend, mockGetObject, mockUpdateSession } =
+const { mockBedrockSend, mockComprehendSend, mockGetObject, mockUpdateSession, mockSendToSession } =
   vi.hoisted(() => ({
     mockBedrockSend: vi.fn(),
     mockComprehendSend: vi.fn(),
     mockGetObject: vi.fn(),
     mockUpdateSession: vi.fn(),
+    mockSendToSession: vi.fn(),
   }))
 
 vi.mock('@aws-sdk/client-bedrock-runtime', () => ({
@@ -34,6 +35,10 @@ vi.mock('../../lib/dynamodb', () => ({
   updateSession: (...args: unknown[]) => mockUpdateSession(...args) as unknown,
 }))
 
+vi.mock('../../lib/websocket', () => ({
+  sendToSession: (...args: unknown[]) => mockSendToSession(...args) as unknown,
+}))
+
 import { handler } from './handler'
 
 const baseInput = {
@@ -50,6 +55,7 @@ const baseInput = {
 describe('caption-generate handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSendToSession.mockResolvedValue(undefined)
     mockGetObject.mockResolvedValue(Buffer.from([1, 2, 3]))
     mockBedrockSend.mockResolvedValue({
       body: new TextEncoder().encode(

--- a/src/functions/caption-generate/handler.ts
+++ b/src/functions/caption-generate/handler.ts
@@ -2,7 +2,8 @@ import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedroc
 import { ComprehendClient, DetectSentimentCommand } from '@aws-sdk/client-comprehend'
 import { getObject } from '../../lib/s3'
 import { updateSession } from '../../lib/dynamodb'
-import type { PipelineInput } from '../../lib/types'
+import { sendToSession } from '../../lib/websocket'
+import type { PipelineInput, ProgressEvent } from '../../lib/types'
 
 const bedrock = new BedrockRuntimeClient({})
 const comprehend = new ComprehendClient({})
@@ -22,8 +23,18 @@ interface BedrockResponse {
   readonly content: readonly { readonly text: string }[]
 }
 
+const notify = async (sessionId: string, progress: number, message: string): Promise<void> => {
+  const event: ProgressEvent = {
+    type: 'statusUpdate',
+    data: { sessionId, status: 'processing', step: 'caption-generate', progress, message },
+  }
+  await sendToSession(sessionId, event).catch(() => undefined)
+}
+
 export const handler = async (event: CaptionInput): Promise<CaptionOutput> => {
   const { sessionId, createdAt, collageKey } = event
+
+  await notify(sessionId, 55, 'キャプション生成中...')
 
   // Get collage image for Bedrock
   const imageBuffer = await getObject(collageKey)

--- a/src/functions/face-detection/handler.test.ts
+++ b/src/functions/face-detection/handler.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-const { mockRekognitionSend } = vi.hoisted(() => ({
+const { mockRekognitionSend, mockSendToSession } = vi.hoisted(() => ({
   mockRekognitionSend: vi.fn(),
+  mockSendToSession: vi.fn(),
 }))
 
 vi.mock('@aws-sdk/client-rekognition', () => ({
@@ -11,6 +12,10 @@ vi.mock('@aws-sdk/client-rekognition', () => ({
   DetectFacesCommand: class {
     constructor(public input: unknown) {}
   },
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToSession: (...args: unknown[]) => mockSendToSession(...args) as unknown,
 }))
 
 import { handler } from './handler'
@@ -37,6 +42,7 @@ const mockFaceDetail = {
 describe('face-detection handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSendToSession.mockResolvedValue(undefined)
   })
 
   it('should detect faces in all images', async () => {

--- a/src/functions/face-detection/handler.ts
+++ b/src/functions/face-detection/handler.ts
@@ -1,5 +1,6 @@
 import { RekognitionClient, DetectFacesCommand } from '@aws-sdk/client-rekognition'
-import type { PipelineInput } from '../../lib/types'
+import { sendToSession } from '../../lib/websocket'
+import type { PipelineInput, ProgressEvent } from '../../lib/types'
 
 const rekognition = new RekognitionClient({})
 
@@ -21,8 +22,18 @@ interface FaceDetectionOutput extends PipelineInput {
   readonly faces: readonly FaceResult[]
 }
 
+const notify = async (sessionId: string, progress: number, message: string): Promise<void> => {
+  const event: ProgressEvent = {
+    type: 'statusUpdate',
+    data: { sessionId, status: 'processing', step: 'face-detection', progress, message },
+  }
+  await sendToSession(sessionId, event).catch(() => undefined)
+}
+
 export const handler = async (event: PipelineInput): Promise<FaceDetectionOutput> => {
-  const { images, bucket } = event
+  const { sessionId, images, bucket } = event
+
+  await notify(sessionId, 5, '顔を検出中...')
 
   const faces = await Promise.all(
     images.map(async (imageKey) => {


### PR DESCRIPTION
## Summary
全パイプライン Lambda で WebSocket `statusUpdate` イベントを送信するよう統一。

### 進捗通知一覧 (全ステップ)
| Lambda | progress | message |
|--------|----------|---------|
| face-detection | 5 | 顔を検出中... |
| filter-apply | 10→30 | フィルター適用中...→完了 |
| collage-generate | 40→50 | コラージュ生成中...→完了 |
| caption-generate | 55 | キャプション生成中... |
| print-prepare | 60→90 | 印刷データ準備中...→完了 |
| pipeline-complete | — | completed イベント |

### CDK
- face-detection に `WEBSOCKET_URL`, `CONNECTIONS_TABLE` 環境変数追加
- face-detection に `execute-api:ManageConnections` + connections テーブル読み取り権限追加

Closes #37

## Test plan
- [x] `npm run test` — 172 tests passed
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors
- [x] `cd cdk && npx cdk synth` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)