### PR TITLE
feat: print-prepare レシート印刷レイアウト完成

### DIFF
--- a/src/functions/print-prepare/handler.test.ts
+++ b/src/functions/print-prepare/handler.test.ts
@@ -137,4 +137,24 @@ describe('print-prepare handler', () => {
     expect(result.printKey).toBe('print-ready/test-uuid.png')
     expect(mockPutObject).toHaveBeenCalledTimes(2)
   })
+
+  it('should apply sentiment-based frame with high positive score', async () => {
+    const result = await handler({
+      ...baseInput,
+      caption: 'ハッピー！',
+      sentimentScore: 0.95,
+    })
+
+    expect(result.printKey).toBe('print-ready/test-uuid.png')
+  })
+
+  it('should apply sentiment-based frame with low score', async () => {
+    const result = await handler({
+      ...baseInput,
+      caption: '悲しい...',
+      sentimentScore: 0.1,
+    })
+
+    expect(result.printKey).toBe('print-ready/test-uuid.png')
+  })
 })

--- a/src/functions/print-prepare/handler.ts
+++ b/src/functions/print-prepare/handler.ts
@@ -58,6 +58,15 @@ const notify = async (sessionId: string, progress: number, message: string): Pro
   await sendToSession(sessionId, event).catch(() => undefined)
 }
 
+/** Create an SVG for the receipt header (service name). */
+const createHeaderSvg = (width: number): Buffer => {
+  const svg = `<svg width="${String(width)}" height="50">
+    <text x="${String(width / 2)}" y="35" font-size="24" font-weight="bold" font-family="sans-serif"
+      text-anchor="middle" fill="black">Receipt Purikura</text>
+  </svg>`
+  return Buffer.from(svg)
+}
+
 /** Create an SVG text overlay for caption. */
 const createCaptionSvg = (text: string, width: number): Buffer => {
   const escaped = text
@@ -71,19 +80,54 @@ const createCaptionSvg = (text: string, width: number): Buffer => {
   return Buffer.from(svg)
 }
 
-/** Create an SVG text overlay for timestamp. */
-const createTimestampSvg = (width: number): Buffer => {
+/** Create an SVG text overlay for filter name + timestamp. */
+const createFooterSvg = (width: number, filterName: string): Buffer => {
   const now = new Date()
   const ts = `${String(now.getFullYear())}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')}`
+  const escaped = filterName
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
   const svg = `<svg width="${String(width)}" height="30">
-    <text x="${String(width / 2)}" y="20" font-size="14" font-family="monospace"
-      text-anchor="middle" fill="gray">${ts}</text>
+    <text x="10" y="20" font-size="12" font-family="monospace" fill="gray">${escaped}</text>
+    <text x="${String(width - 10)}" y="20" font-size="12" font-family="monospace"
+      text-anchor="end" fill="gray">${ts}</text>
+  </svg>`
+  return Buffer.from(svg)
+}
+
+/** Select a decorative border based on sentiment. */
+const createFrameSvg = (width: number, height: number, sentimentScore: number): Buffer => {
+  // Border style varies by sentiment: positive=double, negative=dashed, neutral=single
+  let stroke: string
+  let strokeDasharray: string
+  if (sentimentScore >= 0.7) {
+    stroke = 'black'
+    strokeDasharray = 'none'
+  } else if (sentimentScore <= 0.3) {
+    stroke = 'black'
+    strokeDasharray = '8,4'
+  } else {
+    stroke = 'black'
+    strokeDasharray = 'none'
+  }
+
+  const inset = sentimentScore >= 0.7 ? 4 : 8
+  const strokeWidth = sentimentScore >= 0.7 ? 3 : 2
+  const svg = `<svg width="${String(width)}" height="${String(height)}">
+    <rect x="${String(inset)}" y="${String(inset)}"
+      width="${String(width - inset * 2)}" height="${String(height - inset * 2)}"
+      fill="none" stroke="${stroke}" stroke-width="${String(strokeWidth)}"
+      stroke-dasharray="${strokeDasharray}" rx="4" ry="4"/>
+    ${sentimentScore >= 0.7 ? `<rect x="${String(inset + 5)}" y="${String(inset + 5)}"
+      width="${String(width - (inset + 5) * 2)}" height="${String(height - (inset + 5) * 2)}"
+      fill="none" stroke="black" stroke-width="1" rx="2" ry="2"/>` : ''}
   </svg>`
   return Buffer.from(svg)
 }
 
 export const handler = async (event: PrintPrepareInput): Promise<PrintPrepareOutput> => {
-  const { sessionId, collageKey, caption } = event
+  const { sessionId, collageKey, caption, filter, sentimentScore } = event
 
   await notify(sessionId, 60, '印刷データ準備中...')
 
@@ -101,16 +145,34 @@ export const handler = async (event: PrintPrepareInput): Promise<PrintPrepareOut
     margin: 1,
   })
 
-  // Calculate layout height: collage + caption(40) + timestamp(30) + QR(120+15padding) + margin
+  // Layout: header(50) + collage(576) + caption(40?) + footer(30) + QR(135)
+  const headerHeight = 50
   const captionHeight = caption ? 40 : 0
-  const timestampHeight = 30
+  const footerHeight = 30
   const qrHeight = 135
-  const bottomExtension = captionHeight + timestampHeight + qrHeight
+  const totalHeight = headerHeight + PRINT_WIDTH + captionHeight + footerHeight + qrHeight
 
   // Build composite overlays
   const overlays: sharp.OverlayOptions[] = []
-  let yOffset = PRINT_WIDTH
+  let yOffset = 0
 
+  // Header: service name
+  overlays.push({
+    input: createHeaderSvg(PRINT_WIDTH),
+    left: 0,
+    top: yOffset,
+  })
+  yOffset += headerHeight
+
+  // Collage image
+  overlays.push({
+    input: await sharp(collageBuffer).resize(PRINT_WIDTH, PRINT_WIDTH).toBuffer(),
+    left: 0,
+    top: yOffset,
+  })
+  yOffset += PRINT_WIDTH
+
+  // Caption (if available)
   if (caption) {
     overlays.push({
       input: createCaptionSvg(caption, PRINT_WIDTH),
@@ -120,29 +182,42 @@ export const handler = async (event: PrintPrepareInput): Promise<PrintPrepareOut
     yOffset += captionHeight
   }
 
+  // Footer: filter name + timestamp
   overlays.push({
-    input: createTimestampSvg(PRINT_WIDTH),
+    input: createFooterSvg(PRINT_WIDTH, filter),
     left: 0,
     top: yOffset,
   })
-  yOffset += timestampHeight
+  yOffset += footerHeight
 
+  // QR code
   overlays.push({
     input: await sharp(qrBuffer).resize(120, 120).toBuffer(),
     left: Math.floor((PRINT_WIDTH - 120) / 2),
     top: yOffset + 8,
   })
 
-  // Build print layout
-  const layoutBuffer = await sharp(collageBuffer)
-    .resize(PRINT_WIDTH, PRINT_WIDTH)
-    .extend({ bottom: bottomExtension, background: { r: 255, g: 255, b: 255 } })
+  // Sentiment-based decorative frame overlay (over the entire layout)
+  const score = sentimentScore ?? 0.5
+  overlays.push({
+    input: createFrameSvg(PRINT_WIDTH, totalHeight, score),
+    left: 0,
+    top: 0,
+  })
+
+  // Build print layout on white canvas
+  const layoutBuffer = await sharp({
+    create: {
+      width: PRINT_WIDTH,
+      height: totalHeight,
+      channels: 3 as const,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
     .composite(overlays)
     .greyscale()
     .raw()
     .toBuffer()
-
-  const totalHeight = PRINT_WIDTH + bottomExtension
 
   // Floyd-Steinberg dithering
   const dithered = floydSteinbergDither(


### PR DESCRIPTION
## Summary
仕様書 (step-functions.md, requirements.md) 準拠のフルレイアウトを実装。

### レシートレイアウト構成
```
┌──────────────────────┐
│  Receipt Purikura    │ ← ヘッダー (サービス名)
├──────────────────────┤
│                      │
│    コラージュ画像     │ ← 576x576px
│                      │
├──────────────────────┤
│  AIキャプション       │ ← optional
├──────────────────────┤
│ beauty     2026.03.17│ ← フィルター名 + 日時
├──────────────────────┤
│       [QR code]      │ ← DL URL
└──────────────────────┘
  ※ 感情連動装飾フレーム
```

### 感情連動フレーム
- sentimentScore >= 0.7: 二重線ボーダー (ポジティブ)
- sentimentScore <= 0.3: 破線ボーダー (ネガティブ)
- それ以外: シンプル線ボーダー (ニュートラル)

Closes #39

## Test plan
- [x] `npm run test` — 174 tests passed (感情フレーム2テスト追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)