### PR TITLE
perf: WebSocket クライアントをキャッシュして TCP 接続再利用

### DIFF
--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -13,8 +13,12 @@ const getEndpoint = (): string => {
   return url.replace('wss://', 'https://')
 }
 
-const getClient = (): ApiGatewayManagementApiClient =>
-  new ApiGatewayManagementApiClient({ endpoint: getEndpoint() })
+let cachedClient: ApiGatewayManagementApiClient | undefined
+
+const getClient = (): ApiGatewayManagementApiClient => {
+  cachedClient ??= new ApiGatewayManagementApiClient({ endpoint: getEndpoint() })
+  return cachedClient
+}
 
 /** Send a JSON payload to a specific connection. */
 export const sendToConnection = async (


### PR DESCRIPTION
## Summary
- `sendToConnection` 呼び出しごとに `ApiGatewayManagementApiClient` を新規生成していた問題を修正
- モジュールレベルで遅延初期化 (`??=`) して Lambda 実行中の TCP 接続を再利用

Closes #47

## Test plan
- [x] `npm run test` — 174 tests passed
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)