### PR TITLE
feat: updateSession に許可フィールドのホワイトリスト追加

### DIFF
--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -105,6 +105,25 @@ describe('dynamodb', () => {
       await updateSession('test-id', '2026-03-16T14:30:00Z', {})
       expect(mockSend).not.toHaveBeenCalled()
     })
+
+    it('should filter out disallowed fields', async () => {
+      mockSend.mockResolvedValueOnce({})
+      await updateSession('test-id', '2026-03-16T14:30:00Z', {
+        status: 'completed',
+        sessionId: 'hacked',
+        createdAt: 'hacked',
+      })
+      expect(mockSend).toHaveBeenCalledOnce()
+    })
+
+    it('should skip update entirely when only disallowed fields are provided', async () => {
+      await updateSession('test-id', '2026-03-16T14:30:00Z', {
+        sessionId: 'hacked',
+        createdAt: 'hacked',
+        ttl: 999,
+      })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
   })
 
   describe('putConnection', () => {

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -49,12 +49,24 @@ export const putSession = async (session: Session): Promise<void> => {
   )
 }
 
+const ALLOWED_SESSION_FIELDS = new Set([
+  'status',
+  'caption',
+  'sentiment',
+  'sentimentScore',
+  'originalImageKeys',
+  'filteredImageKeys',
+  'collageImageKey',
+  'printImageKey',
+  'downloadKey',
+])
+
 export const updateSession = async (
   sessionId: string,
   createdAt: string,
   updates: Record<string, unknown>,
 ): Promise<void> => {
-  const entries = Object.entries(updates)
+  const entries = Object.entries(updates).filter(([key]) => ALLOWED_SESSION_FIELDS.has(key))
   if (entries.length === 0) return
 
   const expressionParts: string[] = []


### PR DESCRIPTION
## Summary
- `updateSession` が `Record<string, unknown>` で任意キーの更新を受け付けていた問題を修正
- `ALLOWED_SESSION_FIELDS` ホワイトリストで更新可能フィールドを制限
- キー属性 (`sessionId`, `createdAt`) や内部管理値 (`ttl`, `photoCount`) の上書きを防止

### 許可フィールド
`status`, `caption`, `sentiment`, `sentimentScore`, `originalImageKeys`, `filteredImageKeys`, `collageImageKey`, `printImageKey`, `downloadKey`

Closes #49

## Test plan
- [x] `npm run test` — 176 tests passed (ホワイトリスト検証2テスト追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)