### PR TITLE
fix: API 仕様書との乖離を修正 (step名 + health timestamp + error イベント)

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -28,6 +28,7 @@ export class AppStack extends cdk.Stack {
       captionGenerateFn: api.captionGenerateFn,
       printPrepareFn: api.printPrepareFn,
       pipelineCompleteFn: api.pipelineCompleteFn,
+      pipelineErrorFn: api.pipelineErrorFn,
     })
 
     const realtime = new Realtime(this, 'Realtime', { stage })
@@ -170,6 +171,14 @@ export class AppStack extends cdk.Stack {
     api.pipelineCompleteFn.addToRolePolicy(new iam.PolicyStatement({
       actions: ['iot:Publish'],
       resources: ['*'],
+    }))
+
+    // pipeline-error: DynamoDB write (sessions), connections read, WebSocket
+    storage.sessionsTable.grantWriteData(api.pipelineErrorFn)
+    storage.connectionsTable.grantReadData(api.pipelineErrorFn)
+    api.pipelineErrorFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['execute-api:ManageConnections'],
+      resources: [webSocketApiArn],
     }))
 
     // yaji-comment-fast: S3 GetObject, DynamoDB Query connections, ManageConnections, Rekognition

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -90,6 +90,9 @@ export class Api extends Construct {
   // Pipeline complete Lambda function
   public readonly pipelineCompleteFn: NodejsFunction
 
+  // Pipeline error Lambda function
+  public readonly pipelineErrorFn: NodejsFunction
+
   // Stats Lambda function
   public readonly statsUpdateFn: NodejsFunction
 
@@ -289,6 +292,16 @@ export class Api extends Construct {
       },
     }))
 
+    this.pipelineErrorFn = new NodejsFunction(this, 'PipelineErrorFn', createCommonProps({
+      name: 'pipeline-error',
+      timeout: Duration.seconds(10),
+      environment: {
+        DYNAMODB_TABLE: sessionsTableName,
+        CONNECTIONS_TABLE: connectionsTableName,
+        WEBSOCKET_URL: websocketUrl,
+      },
+    }))
+
     // -------------------------------------------------------
     // Yaji comment Lambda functions
     // -------------------------------------------------------
@@ -364,14 +377,14 @@ export class Api extends Construct {
       },
     })
 
-    // GET /health - Mock Integration
+    // GET /health - Mock Integration with timestamp
     const healthResource = this.restApi.root.addResource('health')
     healthResource.addMethod('GET', new MockIntegration({
       integrationResponses: [
         {
           statusCode: '200',
           responseTemplates: {
-            'application/json': '{"status":"ok"}',
+            'application/json': '{"status":"ok","timestamp":"$context.requestTime"}',
           },
         },
       ],

--- a/cdk/lib/constructs/pipeline.ts
+++ b/cdk/lib/constructs/pipeline.ts
@@ -19,6 +19,7 @@ export interface PipelineProps {
   readonly captionGenerateFn: IFunction
   readonly printPrepareFn: IFunction
   readonly pipelineCompleteFn: IFunction
+  readonly pipelineErrorFn: IFunction
 }
 
 
@@ -149,22 +150,34 @@ export class Pipeline extends Construct {
     })
 
     // -------------------------------------------------------
-    // Chain all phases
+    // Error handler: update status to 'failed' + send WebSocket error event
+    // -------------------------------------------------------
+    const pipelineErrorStep = new LambdaInvoke(this, 'PipelineError', {
+      lambdaFunction: props.pipelineErrorFn,
+      outputPath: '$.Payload',
+    })
+
+    // -------------------------------------------------------
+    // Chain all phases, wrapped in Parallel for global catch
     // Phase1(face+filter) → merge → collage → caption → print → complete
     // -------------------------------------------------------
-    const workflow = Chain.start(phase1)
+    const mainPipeline = Chain.start(phase1)
       .next(mergePhase1)
       .next(collageGenerateStep)
       .next(captionGenerateStep)
       .next(printPrepareStep)
       .next(pipelineCompleteStep)
 
+    const pipelineWithCatch = new Parallel(this, 'PipelineWithCatch')
+      .branch(mainPipeline)
+      .addCatch(pipelineErrorStep, { resultPath: '$.pipelineError' })
+
     this.stateMachine = new StateMachine(this, 'StateMachine', {
       stateMachineName: `receipt-purikura-pipeline-${stage}`,
       stateMachineType: StateMachineType.EXPRESS,
       tracingEnabled: true,
       timeout: Duration.minutes(5),
-      definitionBody: DefinitionBody.fromChainable(workflow),
+      definitionBody: DefinitionBody.fromChainable(pipelineWithCatch),
     })
   }
 }

--- a/src/functions/caption-generate/handler.ts
+++ b/src/functions/caption-generate/handler.ts
@@ -26,7 +26,7 @@ interface BedrockResponse {
 const notify = async (sessionId: string, progress: number, message: string): Promise<void> => {
   const event: ProgressEvent = {
     type: 'statusUpdate',
-    data: { sessionId, status: 'processing', step: 'caption-generate', progress, message },
+    data: { sessionId, status: 'processing', step: 'caption', progress, message },
   }
   await sendToSession(sessionId, event).catch(() => undefined)
 }

--- a/src/functions/collage-generate/handler.ts
+++ b/src/functions/collage-generate/handler.ts
@@ -69,7 +69,7 @@ const smartCropToSquare = async (
 const notify = async (sessionId: string, progress: number, message: string): Promise<void> => {
   const event: ProgressEvent = {
     type: 'statusUpdate',
-    data: { sessionId, status: 'processing', step: 'collage-generate', progress, message },
+    data: { sessionId, status: 'processing', step: 'collage', progress, message },
   }
   await sendToSession(sessionId, event).catch(() => undefined)
 }

--- a/src/functions/filter-apply/handler.ts
+++ b/src/functions/filter-apply/handler.ts
@@ -30,7 +30,7 @@ const applySimpleFilter = (pipeline: sharp.Sharp, filter: Filter): sharp.Sharp =
 const notify = async (sessionId: string, progress: number, message: string): Promise<void> => {
   const event: ProgressEvent = {
     type: 'statusUpdate',
-    data: { sessionId, status: 'processing', step: 'filter-apply', progress, message },
+    data: { sessionId, status: 'processing', step: 'filter', progress, message },
   }
   await sendToSession(sessionId, event).catch(() => undefined)
 }

--- a/src/functions/pipeline-error/handler.test.ts
+++ b/src/functions/pipeline-error/handler.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { mockUpdateSession, mockSendToSession } = vi.hoisted(() => ({
+  mockUpdateSession: vi.fn(),
+  mockSendToSession: vi.fn(),
+}))
+
+vi.mock('../../lib/dynamodb', () => ({
+  updateSession: (...args: unknown[]) => mockUpdateSession(...args) as unknown,
+}))
+
+vi.mock('../../lib/websocket', () => ({
+  sendToSession: (...args: unknown[]) => mockSendToSession(...args) as unknown,
+}))
+
+import { handler } from './handler'
+
+describe('pipeline-error handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdateSession.mockResolvedValue(undefined)
+    mockSendToSession.mockResolvedValue(undefined)
+  })
+
+  it('should update session status to failed and send error event', async () => {
+    await handler({
+      sessionId: 'test-uuid',
+      createdAt: '2026-03-16T14:30:00Z',
+      error: { cause: 'Lambda timeout' },
+    })
+
+    expect(mockUpdateSession).toHaveBeenCalledWith(
+      'test-uuid',
+      '2026-03-16T14:30:00Z',
+      { status: 'failed' },
+    )
+    expect(mockSendToSession).toHaveBeenCalledWith(
+      'test-uuid',
+      expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({
+          sessionId: 'test-uuid',
+          message: '処理中にエラーが発生しました',
+        }) as Record<string, unknown>,
+      }),
+    )
+  })
+
+  it('should skip when sessionId is missing', async () => {
+    await handler({ createdAt: '2026-03-16T14:30:00Z' })
+
+    expect(mockUpdateSession).not.toHaveBeenCalled()
+    expect(mockSendToSession).not.toHaveBeenCalled()
+  })
+
+  it('should not throw when updateSession fails', async () => {
+    mockUpdateSession.mockRejectedValue(new Error('DynamoDB error'))
+
+    await handler({
+      sessionId: 'test-uuid',
+      createdAt: '2026-03-16T14:30:00Z',
+    })
+
+    expect(mockSendToSession).toHaveBeenCalled()
+  })
+
+  it('should not throw when sendToSession fails', async () => {
+    mockSendToSession.mockRejectedValue(new Error('WebSocket error'))
+
+    await expect(handler({
+      sessionId: 'test-uuid',
+      createdAt: '2026-03-16T14:30:00Z',
+    })).resolves.toBeUndefined()
+  })
+})

--- a/src/functions/pipeline-error/handler.ts
+++ b/src/functions/pipeline-error/handler.ts
@@ -1,0 +1,37 @@
+import { updateSession } from '../../lib/dynamodb'
+import { sendToSession } from '../../lib/websocket'
+
+interface PipelineErrorInput {
+  readonly sessionId?: string
+  readonly createdAt?: string
+  readonly error?: unknown
+}
+
+export const handler = async (event: PipelineErrorInput): Promise<void> => {
+  const { sessionId, createdAt } = event
+
+  if (!sessionId || !createdAt) {
+    console.error('pipeline-error: missing sessionId or createdAt', event)
+    return
+  }
+
+  // Update session status to failed
+  try {
+    await updateSession(sessionId, createdAt, { status: 'failed' })
+  } catch (err) {
+    console.error('pipeline-error: failed to update session:', err)
+  }
+
+  // Notify via WebSocket
+  try {
+    await sendToSession(sessionId, {
+      type: 'error',
+      data: {
+        sessionId,
+        message: '処理中にエラーが発生しました',
+      },
+    })
+  } catch (err) {
+    console.error('pipeline-error: failed to send WebSocket error:', err)
+  }
+}

--- a/src/functions/print-prepare/handler.ts
+++ b/src/functions/print-prepare/handler.ts
@@ -53,7 +53,7 @@ const floydSteinbergDither = (pixels: Uint8Array, width: number, height: number)
 const notify = async (sessionId: string, progress: number, message: string): Promise<void> => {
   const event: ProgressEvent = {
     type: 'statusUpdate',
-    data: { sessionId, status: 'processing', step: 'print-prepare', progress, message },
+    data: { sessionId, status: 'processing', step: 'dither', progress, message },
   }
   await sendToSession(sessionId, event).catch(() => undefined)
 }


### PR DESCRIPTION
## Summary

### 1. statusUpdate step 名を仕様に合わせる
| 変更前 | 変更後 (仕様書準拠) |
|--------|-------------------|
| filter-apply | filter |
| collage-generate | collage |
| caption-generate | caption |
| print-prepare | dither |

### 2. health endpoint に timestamp 追加
- Mock Integration の VTL テンプレートで \`$context.requestTime\` を返却
- レスポンス: \`{"status":"ok","timestamp":"17/Mar/2026:15:00:00 +0000"}\`

### 3. パイプライン失敗時の WebSocket error イベント
- \`pipeline-error\` Lambda 新規追加 (21関数目)
- Parallel + Catch でパイプライン全体のエラーをキャッチ
- session status を \`failed\` に更新 + WebSocket \`error\` イベント送信
- CDK: Lambda 定義 + IAM 権限 (DynamoDB write, connections read, ManageConnections)

## Test plan
- [x] \`npm run test\` — 180 tests passed (pipeline-error 4テスト追加)
- [x] \`npm run type-check\` — no errors
- [x] \`npm run lint\` — no errors
- [x] \`cd cdk && npx cdk synth\` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)