### PR TITLE
feat: AppSync サブスクリプション実装 (Task 5.2)

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib'
 import * as iam from 'aws-cdk-lib/aws-iam'
 import { StartingPosition } from 'aws-cdk-lib/aws-lambda'
 import { DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources'
+import * as appsync from 'aws-cdk-lib/aws-appsync'
 import * as events from 'aws-cdk-lib/aws-events'
 import * as targets from 'aws-cdk-lib/aws-events-targets'
 import type { Construct } from 'constructs'
@@ -12,6 +13,7 @@ import { Pipeline } from './constructs/pipeline'
 import { Realtime } from './constructs/realtime'
 import { Waf } from './constructs/waf'
 import { Monitoring } from './constructs/monitoring'
+import { AppSyncApi } from './constructs/appsync'
 import { Cdn } from './constructs/cdn'
 
 export class AppStack extends cdk.Stack {
@@ -40,6 +42,16 @@ export class AppStack extends cdk.Stack {
     })
 
     const realtime = new Realtime(this, 'Realtime', { stage })
+
+    const appSyncApi = new AppSyncApi(this, 'AppSync', {
+      stage,
+      sessionsTable: storage.sessionsTable,
+    })
+
+    // Set environment variables after constructs are created
+    api.statsUpdateFn.addEnvironment('APPSYNC_URL', appSyncApi.api.graphqlUrl)
+    api.statsUpdateFn.addEnvironment('APPSYNC_API_KEY', appSyncApi.api.apiKey ?? '')
+    appSyncApi.api.grant(api.statsUpdateFn, appsync.IamResource.all(), 'appsync:GraphQL')
 
     // Set STATE_MACHINE_ARN on process-start after pipeline is created
     api.processStartFn.addEnvironment(
@@ -305,6 +317,10 @@ export class AppStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'AlarmTopicArn', {
       value: realtime.alarmTopic.topicArn,
+    })
+
+    new cdk.CfnOutput(this, 'AppSyncUrl', {
+      value: appSyncApi.api.graphqlUrl,
     })
   }
 }

--- a/cdk/lib/constructs/appsync.ts
+++ b/cdk/lib/constructs/appsync.ts
@@ -1,0 +1,133 @@
+import { Construct } from 'constructs'
+import { RemovalPolicy } from 'aws-cdk-lib'
+import * as appsync from 'aws-cdk-lib/aws-appsync'
+import type { Table } from 'aws-cdk-lib/aws-dynamodb'
+
+export interface AppSyncProps {
+  readonly stage: string
+  readonly sessionsTable: Table
+}
+
+export class AppSyncApi extends Construct {
+  public readonly api: appsync.GraphqlApi
+
+  constructor(scope: Construct, id: string, props: AppSyncProps) {
+    super(scope, id)
+
+    const { stage, sessionsTable } = props
+
+    // -------------------------------------------------------
+    // AppSync GraphQL API
+    // -------------------------------------------------------
+    this.api = new appsync.GraphqlApi(this, 'Api', {
+      name: `receipt-purikura-appsync-${stage}`,
+      definition: appsync.Definition.fromSchema(
+        appsync.SchemaFile.fromAsset(
+          require('node:path').join(__dirname, '../schema.graphql'),
+        ),
+      ),
+      authorizationConfig: {
+        defaultAuthorization: {
+          authorizationType: appsync.AuthorizationType.API_KEY,
+        },
+      },
+    })
+
+    // -------------------------------------------------------
+    // DynamoDB Data Source
+    // -------------------------------------------------------
+    const sessionsDs = this.api.addDynamoDbDataSource(
+      'SessionsDataSource',
+      sessionsTable,
+    )
+
+    // -------------------------------------------------------
+    // Resolvers
+    // -------------------------------------------------------
+
+    // Query: getStats - scan sessions table for today's stats
+    sessionsDs.createResolver('GetStatsResolver', {
+      typeName: 'Query',
+      fieldName: 'getStats',
+      requestMappingTemplate: appsync.MappingTemplate.fromString(`
+        {
+          "version": "2017-02-28",
+          "operation": "Scan",
+          "limit": 1000
+        }
+      `),
+      responseMappingTemplate: appsync.MappingTemplate.fromString(`
+        #set($total = 0)
+        #set($completed = 0)
+        #set($failed = 0)
+        #foreach($item in $ctx.result.items)
+          #set($total = $total + 1)
+          #if($item.status == "completed" || $item.status == "printed")
+            #set($completed = $completed + 1)
+          #end
+          #if($item.status == "failed")
+            #set($failed = $failed + 1)
+          #end
+        #end
+        {
+          "totalSessions": $total,
+          "completedSessions": $completed,
+          "failedSessions": $failed,
+          "lastUpdated": "$util.time.nowISO8601()"
+        }
+      `),
+    })
+
+    // Query: getSession
+    sessionsDs.createResolver('GetSessionResolver', {
+      typeName: 'Query',
+      fieldName: 'getSession',
+      requestMappingTemplate: appsync.MappingTemplate.fromString(`
+        {
+          "version": "2017-02-28",
+          "operation": "Query",
+          "query": {
+            "expression": "sessionId = :sid",
+            "expressionValues": {
+              ":sid": $util.dynamodb.toDynamoDBJson($ctx.args.sessionId)
+            }
+          },
+          "limit": 1
+        }
+      `),
+      responseMappingTemplate: appsync.MappingTemplate.fromString(`
+        #if($ctx.result.items.size() > 0)
+          $util.toJson($ctx.result.items[0])
+        #else
+          null
+        #end
+      `),
+    })
+
+    // Mutation: publishStats - used by stats-update Lambda to trigger subscription
+    // Uses NONE data source (no backend, just passes through to subscribers)
+    const noneDs = this.api.addNoneDataSource('NoneDataSource')
+
+    noneDs.createResolver('PublishStatsResolver', {
+      typeName: 'Mutation',
+      fieldName: 'publishStats',
+      requestMappingTemplate: appsync.MappingTemplate.fromString(`
+        {
+          "version": "2017-02-28",
+          "payload": {
+            "totalSessions": $ctx.args.input.totalSessions,
+            "completedSessions": $ctx.args.input.completedSessions,
+            "failedSessions": $ctx.args.input.failedSessions,
+            "lastUpdated": "$util.time.nowISO8601()"
+          }
+        }
+      `),
+      responseMappingTemplate: appsync.MappingTemplate.fromString(
+        '$util.toJson($ctx.result)',
+      ),
+    })
+
+    // Remove API key on stack deletion
+    this.api.applyRemovalPolicy(RemovalPolicy.DESTROY)
+  }
+}

--- a/cdk/lib/schema.graphql
+++ b/cdk/lib/schema.graphql
@@ -1,0 +1,36 @@
+type Stats {
+  totalSessions: Int!
+  completedSessions: Int!
+  failedSessions: Int!
+  lastUpdated: String!
+}
+
+type Session {
+  sessionId: String!
+  createdAt: String!
+  status: String!
+  filterType: String!
+  filter: String!
+  caption: String
+  photoCount: Int
+}
+
+input StatsInput {
+  totalSessions: Int!
+  completedSessions: Int!
+  failedSessions: Int!
+}
+
+type Query {
+  getStats: Stats!
+  getSession(sessionId: String!): Session
+}
+
+type Mutation {
+  publishStats(input: StatsInput!): Stats!
+}
+
+type Subscription {
+  onStatsUpdated: Stats
+    @aws_subscribe(mutations: ["publishStats"])
+}

--- a/src/functions/stats-update/handler.test.ts
+++ b/src/functions/stats-update/handler.test.ts
@@ -16,6 +16,9 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
   UpdateCommand: class {
     constructor(public input: unknown) {}
   },
+  GetCommand: class {
+    constructor(public input: unknown) {}
+  },
 }))
 
 import { handler } from './handler'
@@ -50,13 +53,14 @@ describe('stats-update handler', () => {
   it('should increment counter on INSERT', async () => {
     await handler(createStreamEvent('INSERT'), mockContext, noop)
 
-    expect(mockDocClientSend).toHaveBeenCalledOnce()
+    // UpdateCommand + GetCommand (for AppSync publish)
+    expect(mockDocClientSend).toHaveBeenCalled()
   })
 
   it('should update counter on MODIFY', async () => {
     await handler(createStreamEvent('MODIFY'), mockContext, noop)
 
-    expect(mockDocClientSend).toHaveBeenCalledOnce()
+    expect(mockDocClientSend).toHaveBeenCalled()
   })
 
   it('should skip REMOVE events', async () => {
@@ -77,7 +81,7 @@ describe('stats-update handler', () => {
 
     await handler(createStreamEvent('INSERT'), mockContext, noop)
 
-    expect(mockDocClientSend).toHaveBeenCalledOnce()
+    expect(mockDocClientSend).toHaveBeenCalled()
   })
 
   it('should skip when neither STATS_TABLE nor DYNAMODB_TABLE is set', async () => {
@@ -107,6 +111,44 @@ describe('stats-update handler', () => {
     await handler(event, mockContext, noop)
 
     expect(mockDocClientSend).not.toHaveBeenCalled()
+  })
+
+  it('should publish stats to AppSync when APPSYNC_URL is set', async () => {
+    process.env.APPSYNC_URL = 'https://appsync.example.com/graphql'
+    process.env.APPSYNC_API_KEY = 'test-api-key'
+    mockDocClientSend
+      .mockResolvedValueOnce(undefined) // UpdateCommand
+      .mockResolvedValueOnce({ Item: { totalSessions: 5, completed: 3, printed: 1, failed: 1 } }) // GetCommand
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await handler(createStreamEvent('INSERT'), mockContext, noop)
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://appsync.example.com/graphql',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-api-key': 'test-api-key',
+        }) as Record<string, string>,
+      }),
+    )
+
+    delete process.env.APPSYNC_URL
+    delete process.env.APPSYNC_API_KEY
+    vi.unstubAllGlobals()
+  })
+
+  it('should skip AppSync publish when APPSYNC_URL is not set', async () => {
+    delete process.env.APPSYNC_URL
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    await handler(createStreamEvent('INSERT'), mockContext, noop)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
   })
 
   it('should skip records with missing status', async () => {

--- a/src/functions/stats-update/handler.ts
+++ b/src/functions/stats-update/handler.ts
@@ -1,14 +1,47 @@
 import type { DynamoDBStreamHandler } from 'aws-lambda'
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb'
 
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+
+const VALID_STATUSES = new Set(['uploading', 'processing', 'completed', 'printed', 'failed'])
+
+/** Call AppSync publishStats mutation to trigger subscriptions. */
+const publishToAppSync = async (stats: {
+  totalSessions: number
+  completedSessions: number
+  failedSessions: number
+}): Promise<void> => {
+  const apiUrl = process.env.APPSYNC_URL
+  const apiKey = process.env.APPSYNC_API_KEY
+  if (!apiUrl || !apiKey) return
+
+  const query = `mutation PublishStats($input: StatsInput!) {
+    publishStats(input: $input) { totalSessions completedSessions failedSessions lastUpdated }
+  }`
+
+  try {
+    await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      body: JSON.stringify({
+        query,
+        variables: { input: stats },
+      }),
+    })
+  } catch (err) {
+    console.error('AppSync publishStats failed:', err)
+  }
+}
 
 export const handler: DynamoDBStreamHandler = async (event) => {
   const tableName = process.env.STATS_TABLE ?? process.env.DYNAMODB_TABLE
   if (!tableName) return
 
-  const VALID_STATUSES = new Set(['uploading', 'processing', 'completed', 'printed', 'failed'])
+  let updated = false
 
   for (const record of event.Records) {
     if (record.eventName === 'REMOVE') continue
@@ -30,5 +63,27 @@ export const handler: DynamoDBStreamHandler = async (event) => {
         ExpressionAttributeValues: { ':zero': 0, ':one': 1 },
       }),
     )
+    updated = true
+  }
+
+  // Publish aggregated stats to AppSync for real-time dashboard
+  if (updated) {
+    const today = new Date().toISOString().slice(0, 10)
+    try {
+      const result = await docClient.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { date: today },
+        }),
+      )
+      const item = result.Item ?? {}
+      await publishToAppSync({
+        totalSessions: Number(item.totalSessions) || 0,
+        completedSessions: (Number(item.completed) || 0) + (Number(item.printed) || 0),
+        failedSessions: Number(item.failed) || 0,
+      })
+    } catch (err) {
+      console.error('Failed to read stats for AppSync publish:', err)
+    }
   }
 }


### PR DESCRIPTION
## Summary
リアルタイムダッシュボード用の AppSync GraphQL API を実装。

### GraphQL スキーマ
```graphql
type Query {
  getStats: Stats!          # セッション統計
  getSession(sessionId: String!): Session
}
type Mutation {
  publishStats(input: StatsInput!): Stats!  # stats-update から呼出
}
type Subscription {
  onStatsUpdated: Stats     # リアルタイム更新
    @aws_subscribe(mutations: ["publishStats"])
}
```

### データフロー
```
DynamoDB Streams → stats-update Lambda → AppSync publishStats Mutation
                                              ↓
                      Dashboard (フロント) ← Subscription (onStatsUpdated)
```

### CDK
- `appsync.ts`: GraphQL API + DynamoDB DataSource + NONE DataSource + Resolvers
- `schema.graphql`: Stats/Session/StatsInput 型定義
- `app-stack.ts`: AppSync 構築 + stats-update に APPSYNC_URL/API_KEY 環境変数
- CfnOutput: AppSyncUrl

## Test plan
- [x] `npm run test` — 188 tests passed (AppSync publish テスト2件追加)
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors
- [x] `cd cdk && npx cdk synth` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)