### PR TITLE
fix: パイプラインLambdaの2バグ修正 (#69)

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib'
 import * as iam from 'aws-cdk-lib/aws-iam'
+import * as cr from 'aws-cdk-lib/custom-resources'
 import { StartingPosition } from 'aws-cdk-lib/aws-lambda'
 import { DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources'
 import * as appsync from 'aws-cdk-lib/aws-appsync'
@@ -56,6 +57,21 @@ export class AppStack extends cdk.Stack {
       'STATE_MACHINE_ARN',
       pipeline.stateMachine.stateMachineArn,
     )
+
+    // Fetch IoT Data-ATS endpoint dynamically (account-specific subdomain)
+    const iotEndpointResource = new cr.AwsCustomResource(this, 'IotEndpoint', {
+      onCreate: {
+        service: 'Iot',
+        action: 'describeEndpoint',
+        parameters: { endpointType: 'iot:Data-ATS' },
+        physicalResourceId: cr.PhysicalResourceId.fromResponse('endpointAddress'),
+      },
+      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
+        resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE,
+      }),
+    })
+    const iotEndpointAddress = iotEndpointResource.getResponseField('endpointAddress')
+    api.pipelineCompleteFn.addEnvironment('IOT_ENDPOINT', iotEndpointAddress)
 
     // WebSocket Management API ARN for execute-api permissions
     const webSocketApiArn = cdk.Fn.sub(
@@ -210,9 +226,10 @@ export class AppStack extends cdk.Stack {
       resources: [webSocketApiArn],
     }))
 
-    // pipeline-complete: DynamoDB write, connections read, WebSocket, IoT Core
+    // pipeline-complete: DynamoDB write, connections read, S3 read (presigned URL), WebSocket, IoT Core
     storage.sessionsTable.grantWriteData(api.pipelineCompleteFn)
     storage.connectionsTable.grantReadData(api.pipelineCompleteFn)
+    storage.bucket.grantRead(api.pipelineCompleteFn)
     api.pipelineCompleteFn.addToRolePolicy(new iam.PolicyStatement({
       actions: ['execute-api:ManageConnections'],
       resources: [webSocketApiArn],

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -298,6 +298,7 @@ export class Api extends Construct {
         S3_BUCKET: bucketName,
         CONNECTIONS_TABLE: connectionsTableName,
         WEBSOCKET_URL: websocketUrl,
+        DOWNLOAD_DOMAIN: 'https://main.d3aiwm7kus33pv.amplifyapp.com',
       },
     }))
 


### PR DESCRIPTION
## 修正内容

### Bug 1: face-detection — `images` が undefined

**根本原因:** `S3UploadRule` EventBridgeルールが写真アップロード時に自動でStep Functionsを起動していた。このとき渡されるのはS3イベント形式（`images`/`sessionId`なし）。process-startも正しいPipelineInputで別途StartExecutionするため、2つのexecutionが並走し、EventBridge側がクラッシュしていた。

**修正:** `S3UploadRule` を削除。パイプラインの起動はprocess-startのみとする。

### Bug 2: filter-apply — sharp がARM64で動かない

**根本原因:** `createCommonProps`の`bundling`設定に`forceDockerBundling: true`がなく、ホストmacOSの sharpバイナリがバンドルされていた。Lambda (linux-arm64) では読み込めない。

**修正:** `nodeModules`指定時に`forceDockerBundling: true`を追加。Dockerコンテナ内（linux-arm64環境）でビルドすることで正しいバイナリが生成される。対象: filter-apply / collage-generate / print-prepare。

## 確認

- [x] `npm run type-check` パス
- [x] `npm run lint` パス

## デプロイ手順

```bash
cd cdk
npx cdk deploy --all
```

※ `forceDockerBundling`追加によりDockerが必要。初回ビルドは時間がかかる。

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)