### PR TITLE
fix: フロント連携の修正復元（phase_change/filter_select + DynamoDB権限）

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -125,9 +125,9 @@ export class AppStack extends cdk.Stack {
     storage.sessionsTable.grantReadData(api.sessionGetFn)
     storage.bucket.grantRead(api.sessionGetFn)
 
-    // process-start: Step Functions StartExecution, DynamoDB UpdateItem
+    // process-start: Step Functions StartExecution, DynamoDB Query + UpdateItem
     pipeline.stateMachine.grantStartExecution(api.processStartFn)
-    storage.sessionsTable.grantWriteData(api.processStartFn)
+    storage.sessionsTable.grantReadWriteData(api.processStartFn)
 
     // ws-connect: DynamoDB write on connections
     storage.connectionsTable.grantWriteData(api.wsConnectFn)

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -48,9 +48,11 @@ export const WebrtcIceSchema = z.object({
 
 export const ShootingSyncSchema = z.object({
   roomId: z.string().min(1),
-  event: z.enum(['shooting_start', 'countdown', 'shutter', 'shooting_complete']),
+  event: z.enum(['shooting_start', 'countdown', 'shutter', 'shooting_complete', 'phase_change', 'filter_select']),
   sessionId: z.string().optional(),
   totalPhotos: z.number().optional(),
   photoIndex: z.number().optional(),
   count: z.number().optional(),
+  phase: z.string().optional(),
+  filterId: z.string().optional(),
 })


### PR DESCRIPTION
PR #70マージ時にフロント連携用の変更が上書きされていた。phase_change/filter_selectイベントとprocess-startのDynamoDB Read権限を復元。