### PR TITLE
fix: Docker不要のsharpビルドに変更

### DIFF
--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -56,9 +56,14 @@ function createCommonProps(config: LambdaConfig) {
       ...(config.nodeModules
         ? {
             nodeModules: [...config.nodeModules],
-            // Force Docker bundling so native addons (e.g. sharp) are compiled
-            // for linux-arm64 (Lambda Graviton2) instead of the host macOS arch.
-            forceDockerBundling: true,
+            commandHooks: {
+              beforeBundling: () => [],
+              beforeInstall: () => [],
+              afterBundling: (_inputDir: string, outputDir: string) => [
+                // Install sharp for linux-arm64 without Docker
+                `cd ${outputDir} && npm install --os=linux --cpu=arm64 ${config.nodeModules?.join(' ') ?? ''}`,
+              ],
+            },
           }
         : {}),
     },


### PR DESCRIPTION
forceDockerBundling → commandHooks (npm install --os=linux --cpu=arm64)